### PR TITLE
[Insights] Add per-muscle-group weekly volume reporting

### DIFF
--- a/api/src/app/application/dto/insight.py
+++ b/api/src/app/application/dto/insight.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel
 
 class WeeklyVolume(BaseModel):
     week_number: int
+    muscle_group_id: UUID
+    muscle_group_name: str
     sets_count: int
 
 

--- a/api/src/app/application/services/insight_service.py
+++ b/api/src/app/application/services/insight_service.py
@@ -42,7 +42,8 @@ class InsightService:
             # Map week_id to week_number
             week_map = {w.id: w.week_number for w in mesocycle.weeks}
 
-            weekly_sets: defaultdict[int, int] = defaultdict(int)
+            # Key: (week_number, muscle_group_id, muscle_group_name)
+            weekly_sets: defaultdict[tuple[int, UUID, str], int] = defaultdict(int)
             muscle_group_sets: defaultdict[tuple[UUID, str], int] = defaultdict(int)
             total_sets = 0
 
@@ -65,31 +66,48 @@ class InsightService:
                     continue
 
                 for ex in session.exercises:
-                    # Filter by muscle group if requested
-                    is_target = False
-                    mg_ids = [mg.muscle_group.id for mg in ex.exercise.muscle_groups]
+                    # Skip exercises with no muscle groups assigned
+                    if not ex.exercise.muscle_groups:
+                        continue
 
-                    if muscle_group_id is None or muscle_group_id in mg_ids:
-                        is_target = True
+                    # Get working sets count
+                    working_sets = len([s for s in ex.sets if s.actual_reps is not None])
+                    if working_sets == 0:
+                        continue
 
-                    if is_target:
-                        working_sets = len([s for s in ex.sets if s.actual_reps is not None])
-                        weekly_sets[week_num] += working_sets
-                        total_sets += working_sets
+                    # Count sets for each muscle group (PRIMARY and SECONDARY)
+                    for mg_info in ex.exercise.muscle_groups:
+                        mg_id = mg_info.muscle_group.id
+                        mg_name = mg_info.muscle_group.name
 
-                        for mg_info in ex.exercise.muscle_groups:
-                            muscle_group_sets[
-                                (mg_info.muscle_group.id, mg_info.muscle_group.name)
-                            ] += working_sets
+                        # Apply filter if provided
+                        if muscle_group_id is not None and mg_id != muscle_group_id:
+                            continue
 
+                        # Aggregate by (week, muscle_group_id, muscle_group_name)
+                        weekly_sets[(week_num, mg_id, mg_name)] += working_sets
+
+                        # Also track overall muscle group totals
+                        muscle_group_sets[(mg_id, mg_name)] += working_sets
+
+            # Calculate total sets (sum across all muscle groups)
+            # Note: exercises with multiple muscle groups count the same set multiple times.
+            total_sets = sum(muscle_group_sets.values())
+
+            # Create WeeklyVolume entries, sorted by week then muscle group name
             weekly_volumes = [
-                WeeklyVolume(week_number=wn, sets_count=count)
-                for wn, count in sorted(weekly_sets.items())
+                WeeklyVolume(
+                    week_number=key[0],
+                    muscle_group_id=key[1],
+                    muscle_group_name=key[2],
+                    sets_count=count,
+                )
+                for key, count in sorted(weekly_sets.items(), key=lambda x: (x[0][0], x[0][2]))
             ]
 
             muscle_group_breakdown = [
                 MuscleGroupVolume(muscle_group_id=mg[0], muscle_group_name=mg[1], sets_count=count)
-                for mg, count in muscle_group_sets.items()
+                for mg, count in sorted(muscle_group_sets.items(), key=lambda x: x[0][1])
             ]
 
             return VolumeInsight(

--- a/api/src/app/infrastructure/database/repositories/exercise.py
+++ b/api/src/app/infrastructure/database/repositories/exercise.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -66,6 +66,41 @@ class SQLAlchemyExerciseRepository(
         stmt = select(func.count()).select_from(ExerciseTable)
         result = await self._session.execute(stmt)
         return result.scalar() or 0
+
+    async def update(self, entity: Exercise) -> Exercise:
+        stmt = (
+            select(ExerciseTable)
+            .where(ExerciseTable.id == entity.id)
+            .options(selectinload(ExerciseTable.muscle_groups))
+        )
+        result = await self._session.execute(stmt)
+        model_obj = result.scalar_one_or_none()
+
+        if not model_obj:
+            raise ValueError(f"Entity with id {entity.id} not found")
+
+        self._update_model(model_obj, entity)
+
+        await self._session.execute(
+            delete(exercise_muscle_group).where(exercise_muscle_group.c.exercise_id == entity.id)
+        )
+
+        if entity.muscle_groups:
+            await self._session.execute(
+                insert(exercise_muscle_group),
+                [
+                    {
+                        "exercise_id": entity.id,
+                        "muscle_group_id": mg.muscle_group.id,
+                        "role": mg.role,
+                    }
+                    for mg in entity.muscle_groups
+                ],
+            )
+
+        await self._session.flush()
+        await self._session.refresh(model_obj)
+        return self._to_domain(model_obj)
 
     def _to_domain(self, model_obj: ExerciseTable) -> Exercise:
         # Note: In a real implementation, you'd handle the role from the association table

--- a/api/src/app/presentation/graphql/resolvers/insight.py
+++ b/api/src/app/presentation/graphql/resolvers/insight.py
@@ -24,7 +24,12 @@ def map_volume_insight(v: Any) -> VolumeInsight:
     return VolumeInsight(
         mesocycle_id=v.mesocycle_id,
         weekly_volumes=[
-            WeeklyVolume(week_number=wv.week_number, set_count=wv.sets_count)
+            WeeklyVolume(
+                week_number=wv.week_number,
+                muscle_group_id=wv.muscle_group_id,
+                muscle_group_name=wv.muscle_group_name,
+                set_count=wv.sets_count,
+            )
             for wv in v.weekly_volumes
         ],
         total_sets=v.total_sets,

--- a/api/src/app/presentation/graphql/types/insight.py
+++ b/api/src/app/presentation/graphql/types/insight.py
@@ -6,6 +6,8 @@ import strawberry
 @strawberry.type
 class WeeklyVolume:
     week_number: int
+    muscle_group_id: UUID
+    muscle_group_name: str
     set_count: int
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 
 import pytest
 import pytest_asyncio
@@ -10,6 +11,7 @@ from sqlalchemy.pool import StaticPool
 from app.config.loader import load_config as get_config
 from app.infrastructure.database import connection
 from app.infrastructure.database.models.base import Base
+from app.infrastructure.seed import seed_muscle_groups
 from app.main import create_app
 
 
@@ -20,7 +22,6 @@ def anyio_backend():
 
 @pytest_asyncio.fixture(scope="function")
 async def test_engine(anyio_backend):
-    config = get_config()
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
         echo=True,
@@ -54,8 +55,6 @@ async def test_engine(anyio_backend):
 
     await engine.dispose()
     # Wait a bit before deleting to ensure all connections are closed
-    import asyncio
-
     await asyncio.sleep(0.1)
     if os.path.exists("test_db.sqlite"):
         try:
@@ -79,6 +78,10 @@ async def client(test_engine):
         class_=AsyncSession,
         expire_on_commit=False,
     )
+
+    # Seed muscle groups for tests
+    await seed_muscle_groups(session_factory)
+
     app = create_app(engine=test_engine, session_factory=session_factory)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac

--- a/api/tests/integration/test_graphql_api.py
+++ b/api/tests/integration/test_graphql_api.py
@@ -178,6 +178,31 @@ async def test_insights_api(client: AsyncClient, auth_headers: dict):
     )
     routine_id = resp.json()["data"]["createRoutine"]["id"]
 
+    # 2a. Assign muscle group to exercise (needed for volume insights)
+    resp = await client.post(
+        "/graphql",
+        json={"query": "query { muscleGroups { id name } }"},
+        headers=auth_headers,
+    )
+    muscle_groups = resp.json()["data"]["muscleGroups"]
+    lats_mg = next(
+        (mg for mg in muscle_groups if mg["name"] == "Lats"),
+        muscle_groups[0] if muscle_groups else None,
+    )
+    assert lats_mg is not None, "No muscle groups available for testing"
+
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": ex_id,
+                "mgs": [{"muscleGroupId": lats_mg["id"], "role": "PRIMARY"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
     # Add Exercise to Routine
     await client.post(
         "/graphql",
@@ -260,7 +285,12 @@ async def test_insights_api(client: AsyncClient, auth_headers: dict):
         mesocycleVolumeInsight(mesocycleId: $mid) {
             mesocycleId
             totalSets
-            weeklyVolumes { weekNumber setCount }
+            weeklyVolumes { 
+                weekNumber 
+                muscleGroupId 
+                muscleGroupName 
+                setCount 
+            }
         }
     }
     """
@@ -270,6 +300,13 @@ async def test_insights_api(client: AsyncClient, auth_headers: dict):
     assert resp.status_code == 200
     vol_data = resp.json()["data"]["mesocycleVolumeInsight"]
     assert vol_data["totalSets"] >= 1
+    # Verify weekly volumes have muscle group information
+    assert len(vol_data["weeklyVolumes"]) > 0
+    for wv in vol_data["weeklyVolumes"]:
+        assert wv["weekNumber"] is not None
+        assert wv["muscleGroupId"] is not None
+        assert wv["muscleGroupName"] is not None
+        assert wv["setCount"] > 0
 
     # Progressive Overload Insight
     po_query = """

--- a/api/tests/integration/test_volume_insight_muscle_groups.py
+++ b/api/tests/integration/test_volume_insight_muscle_groups.py
@@ -1,0 +1,750 @@
+"""Integration tests for Volume Insight with per-muscle-group weekly breakdown."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.anyio
+async def test_volume_without_filter_multiple_muscle_groups_per_week(
+    client: AsyncClient, auth_headers: dict
+):
+    """Test that weekly volumes show per-muscle-group breakdown when no filter is applied."""
+    # 1. Get muscle groups
+    resp = await client.post(
+        "/graphql",
+        json={"query": "query { muscleGroups { id name } }"},
+        headers=auth_headers,
+    )
+    muscle_groups = resp.json()["data"]["muscleGroups"]
+    chest_mg = next(mg for mg in muscle_groups if mg["name"] == "Chest")
+    biceps_mg = next(mg for mg in muscle_groups if mg["name"] == "Biceps")
+
+    # 2. Create exercises with different muscle groups
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createExercise(input: {name: "Bench Press"}) { id } }'},
+        headers=auth_headers,
+    )
+    bench_id = resp.json()["data"]["createExercise"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createExercise(input: {name: "Bicep Curl"}) { id } }'},
+        headers=auth_headers,
+    )
+    curl_id = resp.json()["data"]["createExercise"]["id"]
+
+    # 3. Assign muscle groups
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": bench_id,
+                "mgs": [{"muscleGroupId": chest_mg["id"], "role": "PRIMARY"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": curl_id,
+                "mgs": [{"muscleGroupId": biceps_mg["id"], "role": "PRIMARY"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    # 4. Create routine with both exercises
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createRoutine(input: {name: "Push Pull"}) { id } }'},
+        headers=auth_headers,
+    )
+    routine_id = resp.json()["data"]["createRoutine"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($rid: UUID!, $eid: UUID!, $order: Int!) { addRoutineExercise(routineId: $rid, input: {exerciseId: $eid, order: $order}) { id } }",
+            "variables": {"rid": routine_id, "eid": bench_id, "order": 1},
+        },
+        headers=auth_headers,
+    )
+    bench_re_id = resp.json()["data"]["addRoutineExercise"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($rid: UUID!, $eid: UUID!, $order: Int!) { addRoutineExercise(routineId: $rid, input: {exerciseId: $eid, order: $order}) { id } }",
+            "variables": {"rid": routine_id, "eid": curl_id, "order": 2},
+        },
+        headers=auth_headers,
+    )
+    curl_re_id = resp.json()["data"]["addRoutineExercise"]["id"]
+
+    # Add extra routine sets so sessions can log multiple sets per exercise
+    for set_number in (2, 3, 4):
+        await client.post(
+            "/graphql",
+            json={
+                "query": "mutation AddSet($reid: UUID!, $input: AddRoutineSetInput!) { addRoutineSet(routineExerciseId: $reid, input: $input) { id } }",
+                "variables": {
+                    "reid": bench_re_id,
+                    "input": {
+                        "setNumber": set_number,
+                        "setType": "STANDARD",
+                        "targetRepsMin": 8,
+                        "targetRepsMax": 12,
+                        "targetRir": 2,
+                    },
+                },
+            },
+            headers=auth_headers,
+        )
+
+    for set_number in (2, 3):
+        await client.post(
+            "/graphql",
+            json={
+                "query": "mutation AddSet($reid: UUID!, $input: AddRoutineSetInput!) { addRoutineSet(routineExerciseId: $reid, input: $input) { id } }",
+                "variables": {
+                    "reid": curl_re_id,
+                    "input": {
+                        "setNumber": set_number,
+                        "setType": "STANDARD",
+                        "targetRepsMin": 8,
+                        "targetRepsMax": 12,
+                        "targetRir": 2,
+                    },
+                },
+            },
+            headers=auth_headers,
+        )
+
+    # 5. Create mesocycle with 2 weeks
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation { createMesocycle(input: {name: "Volume Test", startDate: "2026-06-01"}) { id } }'
+        },
+        headers=auth_headers,
+    )
+    meso_id = resp.json()["data"]["createMesocycle"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation Add($mid: UUID!) { addMesocycleWeek(mesocycleId: $mid, input: {weekNumber: 1, weekType: TRAINING, startDate: "2026-06-01", endDate: "2026-06-07"}) { id } }',
+            "variables": {"mid": meso_id},
+        },
+        headers=auth_headers,
+    )
+    week1_id = resp.json()["data"]["addMesocycleWeek"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation Add($mid: UUID!) { addMesocycleWeek(mesocycleId: $mid, input: {weekNumber: 2, weekType: TRAINING, startDate: "2026-06-08", endDate: "2026-06-14"}) { id } }',
+            "variables": {"mid": meso_id},
+        },
+        headers=auth_headers,
+    )
+    week2_id = resp.json()["data"]["addMesocycleWeek"]["id"]
+
+    # 6. Create planned sessions
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($wid: UUID!, $rid: UUID!) { addPlannedSession(mesocycleWeekId: $wid, input: {routineId: $rid, dayOfWeek: 1}) { id } }",
+            "variables": {"wid": week1_id, "rid": routine_id},
+        },
+        headers=auth_headers,
+    )
+    ps1_id = resp.json()["data"]["addPlannedSession"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($wid: UUID!, $rid: UUID!) { addPlannedSession(mesocycleWeekId: $wid, input: {routineId: $rid, dayOfWeek: 1}) { id } }",
+            "variables": {"wid": week2_id, "rid": routine_id},
+        },
+        headers=auth_headers,
+    )
+    ps2_id = resp.json()["data"]["addPlannedSession"]["id"]
+
+    # 7. Complete sessions with sets
+    async def complete_session_with_sets(ps_id, bench_sets, curl_sets):
+        resp = await client.post(
+            "/graphql",
+            json={
+                "query": "mutation Create($psid: UUID!) { createSession(input: {plannedSessionId: $psid}) { id exercises { id exercise { name } sets { id } } } }",
+                "variables": {"psid": ps_id},
+            },
+            headers=auth_headers,
+        )
+        session_data = resp.json()["data"]["createSession"]
+        session_id = session_data["id"]
+
+        # Start session
+        await client.post(
+            "/graphql",
+            json={"query": f'mutation {{ startSession(id: "{session_id}") {{ id }} }}'},
+            headers=auth_headers,
+        )
+
+        # Log sets for each exercise
+        for ex_data in session_data["exercises"]:
+            ex_name = ex_data["exercise"]["name"]
+            set_count = bench_sets if ex_name == "Bench Press" else curl_sets
+
+            for i in range(set_count):
+                set_id = ex_data["sets"][i]["id"] if i < len(ex_data["sets"]) else None
+                if set_id:
+                    await client.post(
+                        "/graphql",
+                        json={
+                            "query": "mutation Log($sid: UUID!, $w: Decimal!, $r: Int!) { logSetResult(setId: $sid, input: {actualReps: $r, actualWeightKg: $w, actualRir: 2}) { id } }",
+                            "variables": {"sid": set_id, "w": "100.0", "r": 10},
+                        },
+                        headers=auth_headers,
+                    )
+
+        # Complete session
+        await client.post(
+            "/graphql",
+            json={"query": f'mutation {{ completeSession(id: "{session_id}") {{ id }} }}'},
+            headers=auth_headers,
+        )
+
+    # Week 1: 1 set bench, 1 set curl
+    await complete_session_with_sets(ps1_id, 1, 1)
+    # Week 2: 1 set bench, 1 set curl
+    await complete_session_with_sets(ps2_id, 1, 1)
+
+    # 8. Query volume insight WITHOUT filter
+    vol_query = """
+    query GetVolume($mid: UUID!) {
+        mesocycleVolumeInsight(mesocycleId: $mid) {
+            mesocycleId
+            totalSets
+            weeklyVolumes { 
+                weekNumber 
+                muscleGroupId 
+                muscleGroupName 
+                setCount 
+            }
+            muscleGroupBreakdown {
+                muscleGroupId
+                muscleGroupName
+                totalSets
+            }
+        }
+    }
+    """
+    resp = await client.post(
+        "/graphql",
+        json={"query": vol_query, "variables": {"mid": meso_id}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]["mesocycleVolumeInsight"]
+
+    # 9. Assertions
+    weekly_volumes = data["weeklyVolumes"]
+
+    # Should have entries for week 1 (Chest + Biceps) and week 2 (Chest + Biceps) = 4 entries
+    assert len(weekly_volumes) == 4
+
+    # Find specific entries
+    week1_chest = next(
+        (wv for wv in weekly_volumes if wv["weekNumber"] == 1 and wv["muscleGroupName"] == "Chest"),
+        None,
+    )
+    week1_biceps = next(
+        (
+            wv
+            for wv in weekly_volumes
+            if wv["weekNumber"] == 1 and wv["muscleGroupName"] == "Biceps"
+        ),
+        None,
+    )
+    week2_chest = next(
+        (wv for wv in weekly_volumes if wv["weekNumber"] == 2 and wv["muscleGroupName"] == "Chest"),
+        None,
+    )
+    week2_biceps = next(
+        (
+            wv
+            for wv in weekly_volumes
+            if wv["weekNumber"] == 2 and wv["muscleGroupName"] == "Biceps"
+        ),
+        None,
+    )
+
+    assert week1_chest is not None
+    assert week1_chest["setCount"] == 1
+    assert week1_chest["muscleGroupId"] == chest_mg["id"]
+
+    assert week1_biceps is not None
+    assert week1_biceps["setCount"] == 1
+    assert week1_biceps["muscleGroupId"] == biceps_mg["id"]
+
+    assert week2_chest is not None
+    assert week2_chest["setCount"] == 1
+    assert week2_chest["muscleGroupId"] == chest_mg["id"]
+
+    assert week2_biceps is not None
+    assert week2_biceps["setCount"] == 1
+    assert week2_biceps["muscleGroupId"] == biceps_mg["id"]
+
+    # Verify ordering: should be by week number, then muscle group name
+    # Week 1: Biceps (alphabetically before Chest), Chest
+    # Week 2: Biceps, Chest
+    assert weekly_volumes[0]["weekNumber"] == 1
+    assert weekly_volumes[0]["muscleGroupName"] == "Biceps"
+    assert weekly_volumes[1]["weekNumber"] == 1
+    assert weekly_volumes[1]["muscleGroupName"] == "Chest"
+    assert weekly_volumes[2]["weekNumber"] == 2
+    assert weekly_volumes[2]["muscleGroupName"] == "Biceps"
+    assert weekly_volumes[3]["weekNumber"] == 2
+    assert weekly_volumes[3]["muscleGroupName"] == "Chest"
+
+    # Verify muscle group breakdown totals
+    chest_breakdown = next(
+        (mg for mg in data["muscleGroupBreakdown"] if mg["muscleGroupName"] == "Chest"), None
+    )
+    biceps_breakdown = next(
+        (mg for mg in data["muscleGroupBreakdown"] if mg["muscleGroupName"] == "Biceps"), None
+    )
+
+    assert chest_breakdown is not None
+    assert chest_breakdown["totalSets"] == 2  # 1 + 1
+    assert biceps_breakdown is not None
+    assert biceps_breakdown["totalSets"] == 2  # 1 + 1
+
+    # Total sets should be sum of all muscle group sets
+    assert data["totalSets"] == 4  # 2 + 2
+
+
+@pytest.mark.anyio
+async def test_volume_with_filter_single_muscle_group(client: AsyncClient, auth_headers: dict):
+    """Test that filtering by muscleGroupId returns only that muscle group's weekly volumes."""
+    # 1. Get muscle groups
+    resp = await client.post(
+        "/graphql",
+        json={"query": "query { muscleGroups { id name } }"},
+        headers=auth_headers,
+    )
+    muscle_groups = resp.json()["data"]["muscleGroups"]
+    chest_mg = next(mg for mg in muscle_groups if mg["name"] == "Chest")
+    triceps_mg = next(mg for mg in muscle_groups if mg["name"] == "Triceps")
+
+    # 2. Create exercises
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createExercise(input: {name: "Bench Press Filter"}) { id } }'},
+        headers=auth_headers,
+    )
+    bench_id = resp.json()["data"]["createExercise"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createExercise(input: {name: "Tricep Dips"}) { id } }'},
+        headers=auth_headers,
+    )
+    dips_id = resp.json()["data"]["createExercise"]["id"]
+
+    # 3. Assign muscle groups
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": bench_id,
+                "mgs": [{"muscleGroupId": chest_mg["id"], "role": "PRIMARY"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": dips_id,
+                "mgs": [{"muscleGroupId": triceps_mg["id"], "role": "PRIMARY"}],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    # 4. Create routine, mesocycle, and sessions (simplified)
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createRoutine(input: {name: "Filter Test"}) { id } }'},
+        headers=auth_headers,
+    )
+    routine_id = resp.json()["data"]["createRoutine"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($rid: UUID!, $eid: UUID!) { addRoutineExercise(routineId: $rid, input: {exerciseId: $eid, order: 1}) { id } }",
+            "variables": {"rid": routine_id, "eid": bench_id},
+        },
+        headers=auth_headers,
+    )
+    bench_re_id = resp.json()["data"]["addRoutineExercise"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($rid: UUID!, $eid: UUID!) { addRoutineExercise(routineId: $rid, input: {exerciseId: $eid, order: 2}) { id } }",
+            "variables": {"rid": routine_id, "eid": dips_id},
+        },
+        headers=auth_headers,
+    )
+    dips_re_id = resp.json()["data"]["addRoutineExercise"]["id"]
+
+    for re_id in (bench_re_id, dips_re_id):
+        for set_number in (2, 3):
+            await client.post(
+                "/graphql",
+                json={
+                    "query": "mutation AddSet($reid: UUID!, $input: AddRoutineSetInput!) { addRoutineSet(routineExerciseId: $reid, input: $input) { id } }",
+                    "variables": {
+                        "reid": re_id,
+                        "input": {
+                            "setNumber": set_number,
+                            "setType": "STANDARD",
+                            "targetRepsMin": 8,
+                            "targetRepsMax": 12,
+                            "targetRir": 2,
+                        },
+                    },
+                },
+                headers=auth_headers,
+            )
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation { createMesocycle(input: {name: "Filter Meso", startDate: "2026-07-01"}) { id } }'
+        },
+        headers=auth_headers,
+    )
+    meso_id = resp.json()["data"]["createMesocycle"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation Add($mid: UUID!) { addMesocycleWeek(mesocycleId: $mid, input: {weekNumber: 1, weekType: TRAINING, startDate: "2026-07-01", endDate: "2026-07-07"}) { id } }',
+            "variables": {"mid": meso_id},
+        },
+        headers=auth_headers,
+    )
+    week1_id = resp.json()["data"]["addMesocycleWeek"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($wid: UUID!, $rid: UUID!) { addPlannedSession(mesocycleWeekId: $wid, input: {routineId: $rid, dayOfWeek: 1}) { id } }",
+            "variables": {"wid": week1_id, "rid": routine_id},
+        },
+        headers=auth_headers,
+    )
+    ps_id = resp.json()["data"]["addPlannedSession"]["id"]
+
+    # 5. Complete session with sets
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Create($psid: UUID!) { createSession(input: {plannedSessionId: $psid}) { id exercises { id sets { id } } } }",
+            "variables": {"psid": ps_id},
+        },
+        headers=auth_headers,
+    )
+    session_data = resp.json()["data"]["createSession"]
+    session_id = session_data["id"]
+
+    await client.post(
+        "/graphql",
+        json={"query": f'mutation {{ startSession(id: "{session_id}") {{ id }} }}'},
+        headers=auth_headers,
+    )
+
+    # Log 1 set for each exercise
+    for ex_data in session_data["exercises"]:
+        for i in range(min(1, len(ex_data["sets"]))):
+            set_id = ex_data["sets"][i]["id"]
+            await client.post(
+                "/graphql",
+                json={
+                    "query": 'mutation Log($sid: UUID!) { logSetResult(setId: $sid, input: {actualReps: 10, actualWeightKg: "100.0", actualRir: 2}) { id } }',
+                    "variables": {"sid": set_id},
+                },
+                headers=auth_headers,
+            )
+
+    await client.post(
+        "/graphql",
+        json={"query": f'mutation {{ completeSession(id: "{session_id}") {{ id }} }}'},
+        headers=auth_headers,
+    )
+
+    # 6. Query WITH filter for Chest only
+    vol_query = """
+    query GetVolume($mid: UUID!, $mgid: UUID!) {
+        mesocycleVolumeInsight(mesocycleId: $mid, muscleGroupId: $mgid) {
+            weeklyVolumes { 
+                weekNumber 
+                muscleGroupId 
+                muscleGroupName 
+                setCount 
+            }
+        }
+    }
+    """
+    resp = await client.post(
+        "/graphql",
+        json={"query": vol_query, "variables": {"mid": meso_id, "mgid": chest_mg["id"]}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]["mesocycleVolumeInsight"]
+
+    # 7. Assertions
+    weekly_volumes = data["weeklyVolumes"]
+
+    # Should only have Chest entries, no Triceps
+    assert len(weekly_volumes) == 1
+    assert weekly_volumes[0]["weekNumber"] == 1
+    assert weekly_volumes[0]["muscleGroupId"] == chest_mg["id"]
+    assert weekly_volumes[0]["muscleGroupName"] == "Chest"
+    assert weekly_volumes[0]["setCount"] == 1
+
+    # No Triceps entries should be present
+    triceps_entries = [wv for wv in weekly_volumes if wv["muscleGroupName"] == "Triceps"]
+    assert len(triceps_entries) == 0
+
+
+@pytest.mark.anyio
+async def test_volume_exercise_with_multiple_muscle_groups_counts_for_all(
+    client: AsyncClient, auth_headers: dict
+):
+    """Test that exercises with multiple muscle groups count sets for ALL muscle groups."""
+    # 1. Get muscle groups
+    resp = await client.post(
+        "/graphql",
+        json={"query": "query { muscleGroups { id name } }"},
+        headers=auth_headers,
+    )
+    muscle_groups = resp.json()["data"]["muscleGroups"]
+    chest_mg = next(mg for mg in muscle_groups if mg["name"] == "Chest")
+    triceps_mg = next(mg for mg in muscle_groups if mg["name"] == "Triceps")
+
+    # 2. Create exercise with multiple muscle groups (Bench Press: Chest PRIMARY, Triceps SECONDARY)
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createExercise(input: {name: "Bench Press Multi"}) { id } }'},
+        headers=auth_headers,
+    )
+    bench_id = resp.json()["data"]["createExercise"]["id"]
+
+    await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Assign($eid: UUID!, $mgs: [MuscleGroupAssignmentInput!]!) { assignMuscleGroups(exerciseId: $eid, muscleGroupIds: $mgs) { id } }",
+            "variables": {
+                "eid": bench_id,
+                "mgs": [
+                    {"muscleGroupId": chest_mg["id"], "role": "PRIMARY"},
+                    {"muscleGroupId": triceps_mg["id"], "role": "SECONDARY"},
+                ],
+            },
+        },
+        headers=auth_headers,
+    )
+
+    # 3. Create routine, mesocycle, session
+    resp = await client.post(
+        "/graphql",
+        json={"query": 'mutation { createRoutine(input: {name: "Multi MG"}) { id } }'},
+        headers=auth_headers,
+    )
+    routine_id = resp.json()["data"]["createRoutine"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($rid: UUID!, $eid: UUID!) { addRoutineExercise(routineId: $rid, input: {exerciseId: $eid, order: 1}) { id } }",
+            "variables": {"rid": routine_id, "eid": bench_id},
+        },
+        headers=auth_headers,
+    )
+    bench_re_id = resp.json()["data"]["addRoutineExercise"]["id"]
+
+    for set_number in (2, 3):
+        await client.post(
+            "/graphql",
+            json={
+                "query": "mutation AddSet($reid: UUID!, $input: AddRoutineSetInput!) { addRoutineSet(routineExerciseId: $reid, input: $input) { id } }",
+                "variables": {
+                    "reid": bench_re_id,
+                    "input": {
+                        "setNumber": set_number,
+                        "setType": "STANDARD",
+                        "targetRepsMin": 8,
+                        "targetRepsMax": 12,
+                        "targetRir": 2,
+                    },
+                },
+            },
+            headers=auth_headers,
+        )
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation { createMesocycle(input: {name: "Multi MG Meso", startDate: "2026-08-01"}) { id } }'
+        },
+        headers=auth_headers,
+    )
+    meso_id = resp.json()["data"]["createMesocycle"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation Add($mid: UUID!) { addMesocycleWeek(mesocycleId: $mid, input: {weekNumber: 1, weekType: TRAINING, startDate: "2026-08-01", endDate: "2026-08-07"}) { id } }',
+            "variables": {"mid": meso_id},
+        },
+        headers=auth_headers,
+    )
+    week1_id = resp.json()["data"]["addMesocycleWeek"]["id"]
+
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Add($wid: UUID!, $rid: UUID!) { addPlannedSession(mesocycleWeekId: $wid, input: {routineId: $rid, dayOfWeek: 1}) { id } }",
+            "variables": {"wid": week1_id, "rid": routine_id},
+        },
+        headers=auth_headers,
+    )
+    ps_id = resp.json()["data"]["addPlannedSession"]["id"]
+
+    # 4. Complete session with 1 set
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": "mutation Create($psid: UUID!) { createSession(input: {plannedSessionId: $psid}) { id exercises { sets { id } } } }",
+            "variables": {"psid": ps_id},
+        },
+        headers=auth_headers,
+    )
+    session_data = resp.json()["data"]["createSession"]
+    session_id = session_data["id"]
+
+    await client.post(
+        "/graphql",
+        json={"query": f'mutation {{ startSession(id: "{session_id}") {{ id }} }}'},
+        headers=auth_headers,
+    )
+
+    for i in range(1):
+        set_id = session_data["exercises"][0]["sets"][i]["id"]
+        await client.post(
+            "/graphql",
+            json={
+                "query": 'mutation Log($sid: UUID!) { logSetResult(setId: $sid, input: {actualReps: 10, actualWeightKg: "100.0", actualRir: 2}) { id } }',
+                "variables": {"sid": set_id},
+            },
+            headers=auth_headers,
+        )
+
+    await client.post(
+        "/graphql",
+        json={"query": f'mutation {{ completeSession(id: "{session_id}") {{ id }} }}'},
+        headers=auth_headers,
+    )
+
+    # 5. Query volume insight
+    vol_query = """
+    query GetVolume($mid: UUID!) {
+        mesocycleVolumeInsight(mesocycleId: $mid) {
+            weeklyVolumes { 
+                weekNumber 
+                muscleGroupName 
+                setCount 
+            }
+        }
+    }
+    """
+    resp = await client.post(
+        "/graphql",
+        json={"query": vol_query, "variables": {"mid": meso_id}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]["mesocycleVolumeInsight"]
+
+    # 6. Assertions - Both Chest and Triceps should have 1 set
+    weekly_volumes = data["weeklyVolumes"]
+    assert len(weekly_volumes) == 2
+
+    chest_entry = next((wv for wv in weekly_volumes if wv["muscleGroupName"] == "Chest"), None)
+    triceps_entry = next((wv for wv in weekly_volumes if wv["muscleGroupName"] == "Triceps"), None)
+
+    assert chest_entry is not None
+    assert chest_entry["setCount"] == 1
+    assert triceps_entry is not None
+    assert triceps_entry["setCount"] == 1  # Same set counted for both muscle groups
+
+
+@pytest.mark.anyio
+async def test_volume_empty_mesocycle_returns_empty_weekly_volumes(
+    client: AsyncClient, auth_headers: dict
+):
+    """Test that an empty mesocycle returns empty weekly volumes array."""
+    resp = await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation { createMesocycle(input: {name: "Empty Meso", startDate: "2026-09-01"}) { id } }'
+        },
+        headers=auth_headers,
+    )
+    meso_id = resp.json()["data"]["createMesocycle"]["id"]
+
+    # Add a week but no sessions
+    await client.post(
+        "/graphql",
+        json={
+            "query": 'mutation Add($mid: UUID!) { addMesocycleWeek(mesocycleId: $mid, input: {weekNumber: 1, weekType: TRAINING, startDate: "2026-09-01", endDate: "2026-09-07"}) { id } }',
+            "variables": {"mid": meso_id},
+        },
+        headers=auth_headers,
+    )
+
+    vol_query = """
+    query GetVolume($mid: UUID!) {
+        mesocycleVolumeInsight(mesocycleId: $mid) {
+            weeklyVolumes { weekNumber muscleGroupName setCount }
+            totalSets
+        }
+    }
+    """
+    resp = await client.post(
+        "/graphql",
+        json={"query": vol_query, "variables": {"mid": meso_id}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]["mesocycleVolumeInsight"]
+
+    assert data["weeklyVolumes"] == []
+    assert data["totalSets"] == 0


### PR DESCRIPTION
- [x] Investigate the reviewer concern about `_to_domain()` always returning `muscle_groups=[]`
- [x] Fix: make `muscle_groups` optional in `Exercise` entity (`None` = not loaded, `[]` = clear all)
- [x] Fix: update `_to_domain()` to return `muscle_groups=None`
- [x] Fix: update `update()` to only touch the association table when `muscle_groups is not None`
- [x] Fix: update all service `_map_to_dto()` helpers to use `muscle_groups or []` (exercise, routine, session, mesocycle, calendar)
- [x] Update unit tests to use new default `None` for exercises simulating repository returns
- [x] Add integration test verifying a name-only update preserves existing muscle-group assignments
- [x] 114 tests pass, mypy clean, CodeQL clean

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/rcgomezap/workouter/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
