### PR TITLE
[Exercise] Preserve muscle-group assignments when updating exercise metadata

### DIFF
--- a/api/src/app/application/services/calendar_service.py
+++ b/api/src/app/application/services/calendar_service.py
@@ -8,8 +8,8 @@ from app.application.dto.routine import RoutineDTO, RoutineExerciseDTO, RoutineS
 from app.application.dto.session import SessionDTO, SessionExerciseDTO, SessionSetDTO
 from app.application.interfaces.unit_of_work import UnitOfWork
 from app.domain.entities.mesocycle import PlannedSession
-from app.domain.entities.routine import Routine
-from app.domain.entities.session import Session, SessionSet
+from app.domain.entities.routine import Routine, RoutineExercise
+from app.domain.entities.session import Session, SessionExercise, SessionSet
 from app.domain.enums import SessionStatus
 
 
@@ -80,6 +80,32 @@ class CalendarService:
         )
 
     def _map_session_to_dto(self, session: Session) -> SessionDTO:
+        def _map_session_exercise(se: SessionExercise) -> SessionExerciseDTO:
+            mgs = se.exercise.muscle_groups if se.exercise.muscle_groups is not None else []
+            return SessionExerciseDTO(
+                id=se.id,
+                exercise=ExerciseDTO(
+                    id=se.exercise.id,
+                    name=se.exercise.name,
+                    description=se.exercise.description,
+                    equipment=se.exercise.equipment,
+                    muscle_groups=[
+                        ExerciseMuscleGroupDTO(
+                            muscle_group=MuscleGroupDTO(
+                                id=mg.muscle_group.id, name=mg.muscle_group.name
+                            ),
+                            role=mg.role,
+                        )
+                        for mg in mgs
+                    ],
+                ),
+                order=se.order,
+                superset_group=se.superset_group,
+                rest_seconds=se.rest_seconds,
+                notes=se.notes,
+                sets=[self._map_session_set_to_dto(ss) for ss in se.sets],
+            )
+
         return SessionDTO(
             id=session.id,
             planned_session_id=session.planned_session_id,
@@ -89,32 +115,7 @@ class CalendarService:
             started_at=session.started_at,
             completed_at=session.completed_at,
             notes=session.notes,
-            exercises=[
-                SessionExerciseDTO(
-                    id=se.id,
-                    exercise=ExerciseDTO(
-                        id=se.exercise.id,
-                        name=se.exercise.name,
-                        description=se.exercise.description,
-                        equipment=se.exercise.equipment,
-                        muscle_groups=[
-                            ExerciseMuscleGroupDTO(
-                                muscle_group=MuscleGroupDTO(
-                                    id=mg.muscle_group.id, name=mg.muscle_group.name
-                                ),
-                                role=mg.role,
-                            )
-                            for mg in se.exercise.muscle_groups
-                        ],
-                    ),
-                    order=se.order,
-                    superset_group=se.superset_group,
-                    rest_seconds=se.rest_seconds,
-                    notes=se.notes,
-                    sets=[self._map_session_set_to_dto(ss) for ss in se.sets],
-                )
-                for se in session.exercises
-            ],
+            exercises=[_map_session_exercise(se) for se in session.exercises],
         )
 
     def _map_session_set_to_dto(self, ss: SessionSet) -> SessionSetDTO:
@@ -134,47 +135,48 @@ class CalendarService:
         )
 
     def _map_routine_to_dto(self, routine: Routine) -> RoutineDTO:
+        def _map_routine_exercise(re: RoutineExercise) -> RoutineExerciseDTO:
+            mgs = re.exercise.muscle_groups if re.exercise.muscle_groups is not None else []
+            return RoutineExerciseDTO(
+                id=re.id,
+                exercise=ExerciseDTO(
+                    id=re.exercise.id,
+                    name=re.exercise.name,
+                    description=re.exercise.description,
+                    equipment=re.exercise.equipment,
+                    muscle_groups=[
+                        ExerciseMuscleGroupDTO(
+                            muscle_group=MuscleGroupDTO(
+                                id=mg.muscle_group.id, name=mg.muscle_group.name
+                            ),
+                            role=mg.role,
+                        )
+                        for mg in mgs
+                    ],
+                ),
+                order=re.order,
+                superset_group=re.superset_group,
+                rest_seconds=re.rest_seconds,
+                notes=re.notes,
+                sets=[
+                    RoutineSetDTO(
+                        id=rs.id,
+                        set_number=rs.set_number,
+                        set_type=rs.set_type,
+                        target_reps_min=rs.target_reps_min,
+                        target_reps_max=rs.target_reps_max,
+                        target_rir=rs.target_rir,
+                        target_weight_kg=rs.target_weight_kg,
+                        weight_reduction_pct=rs.weight_reduction_pct,
+                        rest_seconds=rs.rest_seconds,
+                    )
+                    for rs in re.sets
+                ],
+            )
+
         return RoutineDTO(
             id=routine.id,
             name=routine.name,
             description=routine.description,
-            exercises=[
-                RoutineExerciseDTO(
-                    id=re.id,
-                    exercise=ExerciseDTO(
-                        id=re.exercise.id,
-                        name=re.exercise.name,
-                        description=re.exercise.description,
-                        equipment=re.exercise.equipment,
-                        muscle_groups=[
-                            ExerciseMuscleGroupDTO(
-                                muscle_group=MuscleGroupDTO(
-                                    id=mg.muscle_group.id, name=mg.muscle_group.name
-                                ),
-                                role=mg.role,
-                            )
-                            for mg in re.exercise.muscle_groups
-                        ],
-                    ),
-                    order=re.order,
-                    superset_group=re.superset_group,
-                    rest_seconds=re.rest_seconds,
-                    notes=re.notes,
-                    sets=[
-                        RoutineSetDTO(
-                            id=rs.id,
-                            set_number=rs.set_number,
-                            set_type=rs.set_type,
-                            target_reps_min=rs.target_reps_min,
-                            target_reps_max=rs.target_reps_max,
-                            target_rir=rs.target_rir,
-                            target_weight_kg=rs.target_weight_kg,
-                            weight_reduction_pct=rs.weight_reduction_pct,
-                            rest_seconds=rs.rest_seconds,
-                        )
-                        for rs in re.sets
-                    ],
-                )
-                for re in routine.exercises
-            ],
+            exercises=[_map_routine_exercise(re) for re in routine.exercises],
         )

--- a/api/src/app/application/services/exercise_service.py
+++ b/api/src/app/application/services/exercise_service.py
@@ -103,6 +103,7 @@ class ExerciseService:
             return self._map_to_dto(exercise)
 
     def _map_to_dto(self, exercise: Exercise) -> ExerciseDTO:
+        muscle_groups = exercise.muscle_groups if exercise.muscle_groups is not None else []
         return ExerciseDTO(
             id=exercise.id,
             name=exercise.name,
@@ -113,6 +114,6 @@ class ExerciseService:
                     muscle_group=MuscleGroupDTO(id=mg.muscle_group.id, name=mg.muscle_group.name),
                     role=mg.role,
                 )
-                for mg in exercise.muscle_groups
+                for mg in muscle_groups
             ],
         )

--- a/api/src/app/application/services/mesocycle_service.py
+++ b/api/src/app/application/services/mesocycle_service.py
@@ -18,7 +18,7 @@ from app.application.dto.pagination import PaginationInput
 from app.application.dto.routine import RoutineDTO, RoutineExerciseDTO, RoutineSetDTO
 from app.application.interfaces.unit_of_work import UnitOfWork
 from app.domain.entities.mesocycle import Mesocycle, MesocycleWeek, PlannedSession
-from app.domain.entities.routine import Routine
+from app.domain.entities.routine import Routine, RoutineExercise
 from app.domain.enums import MesocycleStatus
 from app.domain.exceptions import EntityNotFoundException
 
@@ -306,48 +306,49 @@ class MesocycleService:
         )
 
     def _map_routine_to_dto(self, routine: Routine) -> RoutineDTO:
+        def _map_routine_exercise(re: RoutineExercise) -> RoutineExerciseDTO:
+            mgs = re.exercise.muscle_groups if re.exercise.muscle_groups is not None else []
+            return RoutineExerciseDTO(
+                id=re.id,
+                exercise=ExerciseDTO(
+                    id=re.exercise.id,
+                    name=re.exercise.name,
+                    description=re.exercise.description,
+                    equipment=re.exercise.equipment,
+                    muscle_groups=[
+                        ExerciseMuscleGroupDTO(
+                            muscle_group=MuscleGroupDTO(
+                                id=mg.muscle_group.id, name=mg.muscle_group.name
+                            ),
+                            role=mg.role,
+                        )
+                        for mg in mgs
+                    ],
+                ),
+                order=re.order,
+                superset_group=re.superset_group,
+                rest_seconds=re.rest_seconds,
+                notes=re.notes,
+                sets=[
+                    RoutineSetDTO(
+                        id=rs.id,
+                        set_number=rs.set_number,
+                        set_type=rs.set_type,
+                        target_reps_min=rs.target_reps_min,
+                        target_reps_max=rs.target_reps_max,
+                        target_rir=rs.target_rir,
+                        target_weight_kg=rs.target_weight_kg,
+                        weight_reduction_pct=rs.weight_reduction_pct,
+                        rest_seconds=rs.rest_seconds,
+                    )
+                    for rs in re.sets
+                ],
+            )
+
         # Map full routine including exercises and sets
         return RoutineDTO(
             id=routine.id,
             name=routine.name,
             description=routine.description,
-            exercises=[
-                RoutineExerciseDTO(
-                    id=re.id,
-                    exercise=ExerciseDTO(
-                        id=re.exercise.id,
-                        name=re.exercise.name,
-                        description=re.exercise.description,
-                        equipment=re.exercise.equipment,
-                        muscle_groups=[
-                            ExerciseMuscleGroupDTO(
-                                muscle_group=MuscleGroupDTO(
-                                    id=mg.muscle_group.id, name=mg.muscle_group.name
-                                ),
-                                role=mg.role,
-                            )
-                            for mg in re.exercise.muscle_groups
-                        ],
-                    ),
-                    order=re.order,
-                    superset_group=re.superset_group,
-                    rest_seconds=re.rest_seconds,
-                    notes=re.notes,
-                    sets=[
-                        RoutineSetDTO(
-                            id=rs.id,
-                            set_number=rs.set_number,
-                            set_type=rs.set_type,
-                            target_reps_min=rs.target_reps_min,
-                            target_reps_max=rs.target_reps_max,
-                            target_rir=rs.target_rir,
-                            target_weight_kg=rs.target_weight_kg,
-                            weight_reduction_pct=rs.weight_reduction_pct,
-                            rest_seconds=rs.rest_seconds,
-                        )
-                        for rs in re.sets
-                    ],
-                )
-                for re in routine.exercises
-            ],
+            exercises=[_map_routine_exercise(re) for re in routine.exercises],
         )

--- a/api/src/app/application/services/routine_service.py
+++ b/api/src/app/application/services/routine_service.py
@@ -235,6 +235,7 @@ class RoutineService:
             return True
 
     def _map_re_to_dto(self, re: RoutineExercise) -> RoutineExerciseDTO:
+        muscle_groups = re.exercise.muscle_groups if re.exercise.muscle_groups is not None else []
         return RoutineExerciseDTO(
             id=re.id,
             exercise=ExerciseDTO(
@@ -249,7 +250,7 @@ class RoutineService:
                         ),
                         role=mg.role,
                     )
-                    for mg in re.exercise.muscle_groups
+                    for mg in muscle_groups
                 ],
             ),
             order=re.order,
@@ -277,43 +278,5 @@ class RoutineService:
             id=routine.id,
             name=routine.name,
             description=routine.description,
-            exercises=[
-                RoutineExerciseDTO(
-                    id=re.id,
-                    exercise=ExerciseDTO(
-                        id=re.exercise.id,
-                        name=re.exercise.name,
-                        description=re.exercise.description,
-                        equipment=re.exercise.equipment,
-                        muscle_groups=[
-                            ExerciseMuscleGroupDTO(
-                                muscle_group=MuscleGroupDTO(
-                                    id=mg.muscle_group.id, name=mg.muscle_group.name
-                                ),
-                                role=mg.role,
-                            )
-                            for mg in re.exercise.muscle_groups
-                        ],
-                    ),
-                    order=re.order,
-                    superset_group=re.superset_group,
-                    rest_seconds=re.rest_seconds,
-                    notes=re.notes,
-                    sets=[
-                        RoutineSetDTO(
-                            id=rs.id,
-                            set_number=rs.set_number,
-                            set_type=rs.set_type,
-                            target_reps_min=rs.target_reps_min,
-                            target_reps_max=rs.target_reps_max,
-                            target_rir=rs.target_rir,
-                            target_weight_kg=rs.target_weight_kg,
-                            weight_reduction_pct=rs.weight_reduction_pct,
-                            rest_seconds=rs.rest_seconds,
-                        )
-                        for rs in re.sets
-                    ],
-                )
-                for re in routine.exercises
-            ],
+            exercises=[self._map_re_to_dto(re) for re in routine.exercises],
         )

--- a/api/src/app/application/services/session_service.py
+++ b/api/src/app/application/services/session_service.py
@@ -284,6 +284,12 @@ class SessionService:
             updated_se = await self.uow.session_repository.update_exercise(session_exercise)
             await self.uow.commit()
 
+            updated_mgs = (
+                updated_se.exercise.muscle_groups
+                if updated_se.exercise.muscle_groups is not None
+                else []
+            )
+
             return SessionExerciseDTO(
                 id=updated_se.id,
                 exercise=ExerciseDTO(
@@ -298,7 +304,7 @@ class SessionService:
                             ),
                             role=mg.role,
                         )
-                        for mg in updated_se.exercise.muscle_groups
+                        for mg in updated_mgs
                     ],
                 ),
                 order=updated_se.order,
@@ -352,6 +358,11 @@ class SessionService:
                 raise EntityNotFoundException("SessionExercise", session_exercise_id)
 
             # Map to DTO
+            session_mgs = (
+                session_exercise.exercise.muscle_groups
+                if session_exercise.exercise.muscle_groups is not None
+                else []
+            )
             return SessionExerciseDTO(
                 id=session_exercise.id,
                 exercise=ExerciseDTO(
@@ -366,7 +377,7 @@ class SessionService:
                             ),
                             role=mg.role,
                         )
-                        for mg in session_exercise.exercise.muscle_groups
+                        for mg in session_mgs
                     ],
                 ),
                 order=session_exercise.order,
@@ -412,6 +423,32 @@ class SessionService:
             return True
 
     def _map_to_dto(self, session: Session) -> SessionDTO:
+        def _map_session_exercise_to_dto(se: SessionExercise) -> SessionExerciseDTO:
+            se_mgs = se.exercise.muscle_groups if se.exercise.muscle_groups is not None else []
+            return SessionExerciseDTO(
+                id=se.id,
+                exercise=ExerciseDTO(
+                    id=se.exercise.id,
+                    name=se.exercise.name,
+                    description=se.exercise.description,
+                    equipment=se.exercise.equipment,
+                    muscle_groups=[
+                        ExerciseMuscleGroupDTO(
+                            muscle_group=MuscleGroupDTO(
+                                id=mg.muscle_group.id, name=mg.muscle_group.name
+                            ),
+                            role=mg.role,
+                        )
+                        for mg in se_mgs
+                    ],
+                ),
+                order=se.order,
+                superset_group=se.superset_group,
+                rest_seconds=se.rest_seconds,
+                notes=se.notes,
+                sets=[self._map_set_to_dto(ss) for ss in se.sets],
+            )
+
         return SessionDTO(
             id=session.id,
             planned_session_id=session.planned_session_id,
@@ -421,32 +458,7 @@ class SessionService:
             started_at=session.started_at,
             completed_at=session.completed_at,
             notes=session.notes,
-            exercises=[
-                SessionExerciseDTO(
-                    id=se.id,
-                    exercise=ExerciseDTO(
-                        id=se.exercise.id,
-                        name=se.exercise.name,
-                        description=se.exercise.description,
-                        equipment=se.exercise.equipment,
-                        muscle_groups=[
-                            ExerciseMuscleGroupDTO(
-                                muscle_group=MuscleGroupDTO(
-                                    id=mg.muscle_group.id, name=mg.muscle_group.name
-                                ),
-                                role=mg.role,
-                            )
-                            for mg in se.exercise.muscle_groups
-                        ],
-                    ),
-                    order=se.order,
-                    superset_group=se.superset_group,
-                    rest_seconds=se.rest_seconds,
-                    notes=se.notes,
-                    sets=[self._map_set_to_dto(ss) for ss in se.sets],
-                )
-                for se in session.exercises
-            ],
+            exercises=[_map_session_exercise_to_dto(se) for se in session.exercises],
         )
 
     def _map_set_to_dto(self, ss: SessionSet) -> SessionSetDTO:

--- a/api/src/app/domain/entities/exercise.py
+++ b/api/src/app/domain/entities/exercise.py
@@ -16,4 +16,4 @@ class Exercise(TimestampedEntity):
     name: str
     description: str | None = None
     equipment: str | None = None
-    muscle_groups: list[ExerciseMuscleGroup] = []
+    muscle_groups: list[ExerciseMuscleGroup] | None = None

--- a/api/src/app/infrastructure/database/repositories/exercise.py
+++ b/api/src/app/infrastructure/database/repositories/exercise.py
@@ -81,22 +81,25 @@ class SQLAlchemyExerciseRepository(
 
         self._update_model(model_obj, entity)
 
-        await self._session.execute(
-            delete(exercise_muscle_group).where(exercise_muscle_group.c.exercise_id == entity.id)
-        )
-
-        if entity.muscle_groups:
+        if entity.muscle_groups is not None:
             await self._session.execute(
-                insert(exercise_muscle_group),
-                [
-                    {
-                        "exercise_id": entity.id,
-                        "muscle_group_id": mg.muscle_group.id,
-                        "role": mg.role,
-                    }
-                    for mg in entity.muscle_groups
-                ],
+                delete(exercise_muscle_group).where(
+                    exercise_muscle_group.c.exercise_id == entity.id
+                )
             )
+
+            if entity.muscle_groups:
+                await self._session.execute(
+                    insert(exercise_muscle_group),
+                    [
+                        {
+                            "exercise_id": entity.id,
+                            "muscle_group_id": mg.muscle_group.id,
+                            "role": mg.role,
+                        }
+                        for mg in entity.muscle_groups
+                    ],
+                )
 
         await self._session.flush()
         await self._session.refresh(model_obj)
@@ -114,7 +117,7 @@ class SQLAlchemyExerciseRepository(
             equipment=model_obj.equipment,
             created_at=model_obj.created_at,
             updated_at=model_obj.updated_at,
-            muscle_groups=[],  # TODO: Map muscle groups with roles
+            muscle_groups=None,
         )
 
     def _to_model(self, entity: Exercise) -> ExerciseTable:

--- a/api/src/app/infrastructure/database/repositories/routine.py
+++ b/api/src/app/infrastructure/database/repositories/routine.py
@@ -65,7 +65,7 @@ class SQLAlchemyRoutineRepository(
                 name=re_model.exercise.name,
                 description=re_model.exercise.description,
                 equipment=re_model.exercise.equipment,
-                muscle_groups=[],
+                muscle_groups=None,
             )
             sets = [
                 RoutineSet(
@@ -167,7 +167,7 @@ class SQLAlchemyRoutineRepository(
                         name=re_model.exercise.name,
                         description=re_model.exercise.description,
                         equipment=re_model.exercise.equipment,
-                        muscle_groups=[],
+                        muscle_groups=None,
                     )
 
                 if exercise is None:
@@ -176,7 +176,7 @@ class SQLAlchemyRoutineRepository(
                     exercise = Exercise(
                         id=re_model.exercise_id,
                         name="Unknown Exercise",
-                        muscle_groups=[],
+                        muscle_groups=None,
                     )
 
                 exercises.append(

--- a/api/src/app/infrastructure/database/repositories/session.py
+++ b/api/src/app/infrastructure/database/repositories/session.py
@@ -285,7 +285,7 @@ class SQLAlchemySessionRepository(
             exercise_domain = Exercise(
                 id=model_obj.exercise_id,
                 name="Unknown Exercise",
-                muscle_groups=[],
+                muscle_groups=None,
             )
 
         return SessionExercise(

--- a/api/src/app/presentation/graphql/mutations/exercise.py
+++ b/api/src/app/presentation/graphql/mutations/exercise.py
@@ -6,6 +6,7 @@ from strawberry.types import Info
 from app.application.dto.exercise import CreateExerciseInput as CreateExerciseDTO
 from app.application.dto.exercise import MuscleGroupAssignmentInput as MuscleGroupAssignmentDTO
 from app.application.dto.exercise import UpdateExerciseInput as UpdateExerciseDTO
+from app.domain.enums import MuscleRole as DomainMuscleRole
 from app.presentation.graphql.context import Context
 from app.presentation.graphql.inputs.exercise import (
     CreateExerciseInput,
@@ -53,7 +54,10 @@ class ExerciseMutation:
         muscle_group_ids: list[MuscleGroupAssignmentInput],
     ) -> Exercise:
         dtos = [
-            MuscleGroupAssignmentDTO(muscle_group_id=m.muscle_group_id, role=m.role)
+            MuscleGroupAssignmentDTO(
+                muscle_group_id=m.muscle_group_id,
+                role=DomainMuscleRole(m.role.value),
+            )
             for m in muscle_group_ids
         ]
         e = await info.context.exercise_service.assign_muscle_groups(exercise_id, dtos)

--- a/api/src/app/presentation/graphql/resolvers/exercise.py
+++ b/api/src/app/presentation/graphql/resolvers/exercise.py
@@ -16,6 +16,7 @@ from app.presentation.graphql.types.exercise import (
 
 
 def map_exercise(e: Any) -> Exercise:
+    muscle_groups = e.muscle_groups if e.muscle_groups is not None else []
     return Exercise(
         id=e.id,
         name=e.name,
@@ -26,7 +27,7 @@ def map_exercise(e: Any) -> Exercise:
                 muscle_group=MuscleGroup(id=mg.muscle_group.id, name=mg.muscle_group.name),
                 role=mg.role,
             )
-            for mg in e.muscle_groups
+            for mg in muscle_groups
         ],
     )
 

--- a/api/src/app/presentation/graphql/resolvers/routine.py
+++ b/api/src/app/presentation/graphql/resolvers/routine.py
@@ -31,6 +31,7 @@ def map_routine_set(s: Any) -> RoutineSet:
 
 
 def map_exercise(e: Any) -> Exercise:
+    muscle_groups = e.muscle_groups if e.muscle_groups is not None else []
     return Exercise(
         id=e.id,
         name=e.name,
@@ -41,7 +42,7 @@ def map_exercise(e: Any) -> Exercise:
                 muscle_group=MuscleGroup(id=mg.muscle_group.id, name=mg.muscle_group.name),
                 role=mg.role,
             )
-            for mg in e.muscle_groups
+            for mg in muscle_groups
         ],
     )
 

--- a/api/tests/integration/test_exercise_repository.py
+++ b/api/tests/integration/test_exercise_repository.py
@@ -1,11 +1,12 @@
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import insert
+from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.entities.exercise import Exercise
 from app.domain.entities.muscle_group import MuscleGroup
+from app.domain.enums import MuscleRole
 from app.infrastructure.database.models.exercise import exercise_muscle_group
 from app.infrastructure.database.repositories.exercise import SQLAlchemyExerciseRepository
 from app.infrastructure.database.repositories.muscle_group import SQLAlchemyMuscleGroupRepository
@@ -81,3 +82,40 @@ async def test_exercise_repository_filter_by_muscle_group(db_session: AsyncSessi
     assert chest_exercises[0].name == "Pushup"
     assert count == 1
     assert total_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_update_exercise_preserves_muscle_group_assignments(db_session: AsyncSession):
+    ex_repo = SQLAlchemyExerciseRepository(db_session)
+    mg_repo = SQLAlchemyMuscleGroupRepository(db_session)
+
+    mg = MuscleGroup(id=uuid4(), name="Chest")
+    await mg_repo.add(mg)
+
+    ex = Exercise(id=uuid4(), name="Bench Press", muscle_groups=[])
+    await ex_repo.add(ex)
+
+    await db_session.execute(
+        insert(exercise_muscle_group).values(
+            exercise_id=ex.id,
+            muscle_group_id=mg.id,
+            role=MuscleRole.PRIMARY.value,
+        )
+    )
+    await db_session.commit()
+
+    fetched = await ex_repo.get_by_id(ex.id)
+    assert fetched is not None
+    assert fetched.muscle_groups is None
+
+    fetched.name = "Incline Bench Press"
+    await ex_repo.update(fetched)
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(
+            select(exercise_muscle_group).where(exercise_muscle_group.c.exercise_id == ex.id)
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].muscle_group_id == mg.id

--- a/api/tests/unit/services/test_exercise_service.py
+++ b/api/tests/unit/services/test_exercise_service.py
@@ -122,6 +122,23 @@ async def test_update_exercise_full_fields(service, mock_uow):
 
 
 @pytest.mark.asyncio
+async def test_update_exercise_preserves_unloaded_muscle_groups(service, mock_uow):
+    ex_id = uuid4()
+    existing_ex = Exercise(id=ex_id, name="Old Name", muscle_groups=None)
+    update_input = UpdateExerciseInput(name="New Name")
+
+    mock_uow.exercise_repository.get_by_id = AsyncMock(return_value=existing_ex)
+    mock_uow.exercise_repository.update = AsyncMock(return_value=existing_ex)
+    mock_uow.commit = AsyncMock()
+
+    await service.update_exercise(ex_id, update_input)
+
+    updated_entity = mock_uow.exercise_repository.update.call_args.args[0]
+    assert updated_entity.muscle_groups is None
+    mock_uow.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_update_exercise_not_found(service, mock_uow):
     # Arrange
     ex_id = uuid4()


### PR DESCRIPTION
## Summary
- fix a data-loss regression where `updateExercise` could wipe `exercise_muscle_group` rows by introducing a sentinel distinction between "muscle groups not loaded" (`None`) and "explicitly set/clear" (`list`)
- update exercise mapping paths to safely handle optional `muscle_groups` values in services and GraphQL resolvers, preventing iteration errors when associations are intentionally not loaded
- align nested exercise mapping in routine/session repositories with the same sentinel behavior and add a domain-role conversion in `assignMuscleGroups` GraphQL mutation input handling
- add regression coverage for preserving assignments during exercise metadata updates (`tests/integration/test_exercise_repository.py`, `tests/unit/services/test_exercise_service.py`)

## Validation
- `uv run pytest -q --tb=short --disable-warnings` (116 passed)
- `uv run mypy src` (success)