### PR TITLE
[CLI] Implement core infrastructure and domain handling for issue #7

### DIFF
--- a/cli/src/workouter_cli/domain/__init__.py
+++ b/cli/src/workouter_cli/domain/__init__.py
@@ -1,1 +1,11 @@
 """Domain layer."""
+
+from workouter_cli.domain.exceptions import (
+    APIError,
+    AuthError,
+    CLIError,
+    NetworkError,
+    ValidationError,
+)
+
+__all__ = ["APIError", "AuthError", "CLIError", "NetworkError", "ValidationError"]

--- a/cli/src/workouter_cli/domain/exceptions.py
+++ b/cli/src/workouter_cli/domain/exceptions.py
@@ -1,0 +1,44 @@
+"""Domain exceptions with semantic exit codes."""
+
+from workouter_cli.utils.exit_codes import ExitCode
+
+
+class CLIError(Exception):
+    """Base exception for CLI failures with a semantic exit code."""
+
+    def __init__(self, message: str, exit_code: ExitCode, code: str = "CLI_ERROR") -> None:
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+        self.code = code
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ValidationError(CLIError):
+    """Raised when user-provided input is invalid."""
+
+    def __init__(self, message: str, code: str = "VALIDATION_ERROR") -> None:
+        super().__init__(message=message, exit_code=ExitCode.USER_ERROR, code=code)
+
+
+class APIError(CLIError):
+    """Raised when the API rejects a valid request."""
+
+    def __init__(self, message: str, code: str = "API_ERROR") -> None:
+        super().__init__(message=message, exit_code=ExitCode.API_ERROR, code=code)
+
+
+class AuthError(CLIError):
+    """Raised when authentication or authorization fails."""
+
+    def __init__(self, message: str, code: str = "AUTH_ERROR") -> None:
+        super().__init__(message=message, exit_code=ExitCode.AUTH_ERROR, code=code)
+
+
+class NetworkError(CLIError):
+    """Raised when network or transport failures happen."""
+
+    def __init__(self, message: str, code: str = "NETWORK_ERROR") -> None:
+        super().__init__(message=message, exit_code=ExitCode.NETWORK_ERROR, code=code)

--- a/cli/src/workouter_cli/infrastructure/graphql/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/__init__.py
@@ -1,1 +1,5 @@
 """GraphQL infrastructure package."""
+
+from workouter_cli.infrastructure.graphql.client import GraphQLClient, map_graphql_error
+
+__all__ = ["GraphQLClient", "map_graphql_error"]

--- a/cli/src/workouter_cli/infrastructure/graphql/client.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/client.py
@@ -1,0 +1,54 @@
+"""GraphQL client wrapper and error mapping utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gql import Client, gql
+from gql.transport.httpx import HTTPXAsyncTransport
+
+from workouter_cli.domain.exceptions import (
+    APIError,
+    AuthError,
+    CLIError,
+    NetworkError,
+    ValidationError,
+)
+
+
+class GraphQLClient:
+    """Thin wrapper around gql client with configured transport."""
+
+    def __init__(self, url: str, api_key: str, timeout: int) -> None:
+        self.transport = HTTPXAsyncTransport(
+            url=url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=timeout,
+        )
+        self.client = Client(transport=self.transport, fetch_schema_from_transport=False)
+
+    async def execute(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Execute a GraphQL query/mutation asynchronously."""
+
+        async with self.client as session:
+            result = await session.execute(gql(query), variable_values=variables)
+            return dict(result)
+
+
+def map_graphql_error(error: dict[str, Any]) -> CLIError:
+    """Map GraphQL error payload to domain-specific CLI exceptions."""
+
+    message = str(error.get("message", "Unexpected GraphQL error"))
+    extensions = error.get("extensions")
+    if isinstance(extensions, dict):
+        code = str(extensions.get("code", "INTERNAL_ERROR"))
+    else:
+        code = "INTERNAL_ERROR"
+
+    if code == "VALIDATION_ERROR":
+        return ValidationError(message=message, code=code)
+    if code in {"NOT_FOUND", "CONFLICT", "API_ERROR"}:
+        return APIError(message=message, code=code)
+    if code in {"AUTH_ERROR", "UNAUTHORIZED"}:
+        return AuthError(message=message, code=code)
+    return NetworkError(message=message, code=code)

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -3,6 +3,7 @@
 import click
 
 from workouter_cli.infrastructure.config.loader import ConfigError, load_config
+from workouter_cli.presentation.middleware.logging import setup_logging
 
 
 @click.group()
@@ -21,7 +22,9 @@ def cli(ctx: click.Context) -> None:
         return
 
     try:
-        ctx.obj = {"config": load_config()}
+        config = load_config()
+        setup_logging(config)
+        ctx.obj = {"config": config}
     except ConfigError as error:
         click.echo(f"Error: {error}", err=True)
         raise click.exceptions.Exit(error.exit_code.value) from error

--- a/cli/src/workouter_cli/presentation/middleware/logging.py
+++ b/cli/src/workouter_cli/presentation/middleware/logging.py
@@ -1,0 +1,57 @@
+"""Structured logging setup for CLI runtime."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import MutableMapping
+from typing import Any
+
+import structlog
+
+from workouter_cli.infrastructure.config.schema import Config
+
+
+def _configure_stdlib_logging(level_name: str) -> None:
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    root_logger.addHandler(handler)
+    root_logger.setLevel(getattr(logging, level_name, logging.INFO))
+
+
+def _add_event_key(
+    _: Any, __: str, event_dict: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
+    if "event" not in event_dict and "message" in event_dict:
+        event_dict["event"] = str(event_dict["message"])
+    return event_dict
+
+
+def setup_logging(config: Config) -> None:
+    """Configure structlog to emit logs to stderr only."""
+
+    _configure_stdlib_logging(config.log_level)
+
+    renderer: structlog.types.Processor
+    if config.log_level == "DEBUG":
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            _add_event_key,
+            renderer,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )

--- a/cli/tests/unit/test_domain_exceptions.py
+++ b/cli/tests/unit/test_domain_exceptions.py
@@ -1,0 +1,45 @@
+from workouter_cli.domain.exceptions import (
+    APIError,
+    AuthError,
+    CLIError,
+    NetworkError,
+    ValidationError,
+)
+from workouter_cli.utils.exit_codes import ExitCode
+
+
+def test_cli_error_keeps_message_and_exit_code() -> None:
+    error = CLIError(message="boom", exit_code=ExitCode.API_ERROR, code="X")
+
+    assert str(error) == "boom"
+    assert error.exit_code == ExitCode.API_ERROR
+    assert error.code == "X"
+
+
+def test_validation_error_defaults() -> None:
+    error = ValidationError("bad input")
+
+    assert error.exit_code == ExitCode.USER_ERROR
+    assert error.code == "VALIDATION_ERROR"
+    assert str(error) == "bad input"
+
+
+def test_api_error_defaults() -> None:
+    error = APIError("api rejected")
+
+    assert error.exit_code == ExitCode.API_ERROR
+    assert error.code == "API_ERROR"
+
+
+def test_auth_error_defaults() -> None:
+    error = AuthError("unauthorized")
+
+    assert error.exit_code == ExitCode.AUTH_ERROR
+    assert error.code == "AUTH_ERROR"
+
+
+def test_network_error_defaults() -> None:
+    error = NetworkError("timeout")
+
+    assert error.exit_code == ExitCode.NETWORK_ERROR
+    assert error.code == "NETWORK_ERROR"

--- a/cli/tests/unit/test_graphql_client.py
+++ b/cli/tests/unit/test_graphql_client.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.domain.exceptions import APIError, AuthError, NetworkError, ValidationError
+from workouter_cli.infrastructure.graphql.client import GraphQLClient, map_graphql_error
+
+
+def test_graphql_client_builds_transport() -> None:
+    client = GraphQLClient(url="http://localhost:8000/graphql", api_key="k", timeout=45)
+
+    assert str(client.transport.url) == "http://localhost:8000/graphql"
+    assert client.transport.kwargs["headers"] == {"Authorization": "Bearer k"}
+    assert client.transport.kwargs["timeout"] == 45
+
+
+@pytest.mark.asyncio
+async def test_graphql_client_execute_calls_session_with_variables() -> None:
+    client = GraphQLClient(url="http://localhost:8000/graphql", api_key="k", timeout=30)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value={"ok": True})
+
+    class DummyContext:
+        async def __aenter__(self) -> AsyncMock:
+            return session
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    client.client = DummyContext()  # type: ignore[assignment]
+
+    result = await client.execute("query Ping { ping }", {"x": 1})
+
+    assert result == {"ok": True}
+    session.execute.assert_awaited_once()
+    assert session.execute.await_args.kwargs["variable_values"] == {"x": 1}
+
+
+def test_map_graphql_error_validation() -> None:
+    err = map_graphql_error({"message": "invalid", "extensions": {"code": "VALIDATION_ERROR"}})
+    assert isinstance(err, ValidationError)
+
+
+def test_map_graphql_error_api() -> None:
+    err = map_graphql_error({"message": "missing", "extensions": {"code": "NOT_FOUND"}})
+    assert isinstance(err, APIError)
+
+
+def test_map_graphql_error_auth() -> None:
+    err = map_graphql_error({"message": "no auth", "extensions": {"code": "AUTH_ERROR"}})
+    assert isinstance(err, AuthError)
+
+
+def test_map_graphql_error_fallback() -> None:
+    err = map_graphql_error({"message": "boom", "extensions": {"code": "SOMETHING_ELSE"}})
+    assert isinstance(err, NetworkError)

--- a/cli/tests/unit/test_logging.py
+++ b/cli/tests/unit/test_logging.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import io
+import logging
+from typing import cast
+
+import structlog
+
+from workouter_cli.infrastructure.config.schema import Config
+from workouter_cli.presentation.middleware.logging import setup_logging
+
+
+def _capture_stderr() -> io.StringIO:
+    root = logging.getLogger()
+    assert root.handlers
+    stream = io.StringIO()
+    handler = cast(logging.StreamHandler[io.StringIO], root.handlers[0])
+    handler.setStream(stream)
+    return stream
+
+
+def test_setup_logging_uses_json_renderer_for_debug() -> None:
+    config = Config.model_validate(
+        {
+            "api_url": "http://localhost:8000/graphql",
+            "api_key": "k",
+            "timeout": 30,
+            "log_level": "DEBUG",
+        }
+    )
+
+    setup_logging(config)
+    stream = _capture_stderr()
+
+    structlog.get_logger().info("debug message", key="value")
+    output = stream.getvalue()
+
+    assert '"event": "debug message"' in output
+    assert '"key": "value"' in output
+
+
+def test_setup_logging_uses_console_renderer_for_non_debug() -> None:
+    config = Config.model_validate(
+        {
+            "api_url": "http://localhost:8000/graphql",
+            "api_key": "k",
+            "timeout": 30,
+            "log_level": "INFO",
+        }
+    )
+
+    setup_logging(config)
+    stream = _capture_stderr()
+
+    structlog.get_logger().info("plain message", key="value")
+    output = stream.getvalue()
+
+    assert "plain message" in output
+    assert "key" in output
+
+
+def test_logging_does_not_write_to_stdout(capsys) -> None:  # type: ignore[no-untyped-def]
+    config = Config.model_validate(
+        {
+            "api_url": "http://localhost:8000/graphql",
+            "api_key": "k",
+            "timeout": 30,
+            "log_level": "INFO",
+        }
+    )
+
+    setup_logging(config)
+    structlog.get_logger().info("stderr only")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "stderr only" in captured.err


### PR DESCRIPTION
## Summary
- implement structured logging setup via `setup_logging(config)` with `JSONRenderer` in DEBUG and `ConsoleRenderer` otherwise, routing logs to stderr
- add domain exception hierarchy (`CLIError`, `ValidationError`, `APIError`, `AuthError`, `NetworkError`) with semantic `ExitCode` mapping
- introduce GraphQL infrastructure wrapper (`GraphQLClient`) and `map_graphql_error()` to translate GraphQL error payloads into domain exceptions
- wire logging initialization into CLI startup after config load
- add unit tests for logging behavior, domain exception defaults, GraphQL transport setup/execute path, and GraphQL error mapping

## Validation
- `uv run mypy src tests`
- `uv run ruff check .`
- `uv run pytest -q --tb=short --disable-warnings`

Closes #7