### PR TITLE
[CLI] Build presentation layer foundation (issue #9)

### DIFF
--- a/cli/src/workouter_cli/application/formatters/__init__.py
+++ b/cli/src/workouter_cli/application/formatters/__init__.py
@@ -1,1 +1,8 @@
-"""Application formatters package."""
+"""Application formatter exports."""
+
+from workouter_cli.application.formatters.base import Formatter
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.application.formatters.json import JsonFormatter
+from workouter_cli.application.formatters.table import TableFormatter
+
+__all__ = ["Formatter", "JsonFormatter", "TableFormatter", "get_formatter"]

--- a/cli/src/workouter_cli/application/formatters/base.py
+++ b/cli/src/workouter_cli/application/formatters/base.py
@@ -1,0 +1,16 @@
+"""Formatter strategy protocol used by presentation commands."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from rich.table import Table
+
+FormatterOutput = str | Table
+
+
+class Formatter(Protocol):
+    """Contract for command output formatters."""
+
+    def format(self, data: Any, command: str) -> FormatterOutput:
+        """Format command payload for display."""

--- a/cli/src/workouter_cli/application/formatters/factory.py
+++ b/cli/src/workouter_cli/application/formatters/factory.py
@@ -1,0 +1,15 @@
+"""Factory for choosing output formatter strategy."""
+
+from __future__ import annotations
+
+from workouter_cli.application.formatters.base import Formatter
+from workouter_cli.application.formatters.json import JsonFormatter
+from workouter_cli.application.formatters.table import TableFormatter
+
+
+def get_formatter(output_json: bool) -> Formatter:
+    """Select formatter based on global JSON output flag."""
+
+    if output_json:
+        return JsonFormatter()
+    return TableFormatter()

--- a/cli/src/workouter_cli/application/formatters/json.py
+++ b/cli/src/workouter_cli/application/formatters/json.py
@@ -1,0 +1,22 @@
+"""JSON output formatter for automation-friendly output."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+
+class JsonFormatter:
+    """Render payloads as strict, single-line JSON."""
+
+    def format(self, data: Any, command: str) -> str:
+        payload = {
+            "success": True,
+            "data": data,
+            "metadata": {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "command": command,
+            },
+        }
+        return json.dumps(payload, separators=(",", ":"), default=str)

--- a/cli/src/workouter_cli/application/formatters/table.py
+++ b/cli/src/workouter_cli/application/formatters/table.py
@@ -1,0 +1,46 @@
+"""Rich table formatter for human-readable output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.table import Table
+
+
+class TableFormatter:
+    """Render list and mapping payloads as Rich tables."""
+
+    def format(self, data: Any, command: str) -> Table:
+        table = Table(title=command)
+
+        if isinstance(data, list):
+            if not data:
+                table.add_column("result")
+                table.add_row("No data")
+                return table
+
+            first_row = data[0]
+            if isinstance(first_row, dict):
+                columns = [str(key) for key in first_row]
+                for column in columns:
+                    table.add_column(column)
+                for item in data:
+                    row = [str(item.get(column, "")) for column in columns]
+                    table.add_row(*row)
+                return table
+
+            table.add_column("value")
+            for item in data:
+                table.add_row(str(item))
+            return table
+
+        if isinstance(data, dict):
+            table.add_column("field")
+            table.add_column("value")
+            for key, value in data.items():
+                table.add_row(str(key), str(value))
+            return table
+
+        table.add_column("value")
+        table.add_row(str(data))
+        return table

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -1,15 +1,48 @@
 """CLI entry point."""
 
+from __future__ import annotations
+
 import click
+from rich.console import Console
 
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.exceptions import AuthError, CLIError
 from workouter_cli.infrastructure.config.loader import ConfigError, load_config
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.presentation.context import CLIContext
+from workouter_cli.presentation.middleware.error_handler import (
+    handle_cli_error,
+    handle_unexpected_error,
+)
 from workouter_cli.presentation.middleware.logging import setup_logging
+from workouter_cli.utils.exit_codes import ExitCode
 
 
-@click.group()
+class SafeGroup(click.Group):
+    """Click group with centralized CLI error handling."""
+
+    def invoke(self, ctx: click.Context) -> object:
+        output_json = bool(ctx.params.get("output_json", False))
+        command = ctx.command_path
+
+        try:
+            return super().invoke(ctx)
+        except CLIError as error:
+            handle_cli_error(error, output_json=output_json, command=command)
+        except click.exceptions.Exit:
+            raise
+        except click.ClickException:
+            raise
+        except Exception as error:  # pragma: no cover - defensive fallback
+            handle_unexpected_error(error, output_json=output_json, command=command)
+
+
+@click.group(cls=SafeGroup)
+@click.option("--json", "output_json", is_flag=True, help="Output machine-readable JSON")
+@click.option("--timeout", type=int, default=None, help="Override request timeout in seconds")
 @click.version_option(package_name="workouter-cli")
 @click.pass_context
-def cli(ctx: click.Context) -> None:
+def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
     """Workouter CLI."""
 
     if ctx.resilient_parsing:
@@ -23,11 +56,24 @@ def cli(ctx: click.Context) -> None:
 
     try:
         config = load_config()
+        effective_timeout = timeout if timeout is not None else config.timeout
         setup_logging(config)
-        ctx.obj = {"config": config}
+        client = GraphQLClient(
+            url=str(config.api_url), api_key=config.api_key, timeout=effective_timeout
+        )
+        ctx.obj = CLIContext(
+            config=config,
+            client=client,
+            output_json=output_json,
+            timeout=effective_timeout,
+        )
     except ConfigError as error:
-        click.echo(f"Error: {error}", err=True)
-        raise click.exceptions.Exit(error.exit_code.value) from error
+        code = "AUTH_ERROR" if error.exit_code == ExitCode.AUTH_ERROR else "VALIDATION_ERROR"
+        handle_cli_error(
+            CLIError(message=str(error), exit_code=error.exit_code, code=code),
+            output_json=output_json,
+            command=ctx.command_path,
+        )
 
 
 @cli.command(name="schema")
@@ -38,9 +84,22 @@ def schema() -> None:
 
 
 @cli.command(name="ping")
-@click.pass_context
-def ping(ctx: click.Context) -> None:
+@click.pass_obj
+def ping(ctx: CLIContext) -> None:
     """Validate startup and print ready."""
 
-    _ = ctx.obj["config"]
-    click.echo("ready")
+    formatter = get_formatter(ctx.output_json)
+    payload = {"message": "ready", "timeout": ctx.timeout}
+    rendered = formatter.format(payload, command="ping")
+
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+@cli.command(name="raise-auth", hidden=True)
+def raise_auth() -> None:
+    """Test-only command that raises AuthError."""
+
+    raise AuthError("Invalid API key")

--- a/cli/src/workouter_cli/presentation/context.py
+++ b/cli/src/workouter_cli/presentation/context.py
@@ -1,0 +1,18 @@
+"""Click dependency-injection context object."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from workouter_cli.infrastructure.config.schema import Config
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+
+
+@dataclass(slots=True)
+class CLIContext:
+    """Runtime dependencies shared across commands."""
+
+    config: Config
+    client: GraphQLClient
+    output_json: bool
+    timeout: int

--- a/cli/src/workouter_cli/presentation/middleware/__init__.py
+++ b/cli/src/workouter_cli/presentation/middleware/__init__.py
@@ -1,1 +1,9 @@
-"""Presentation middleware package."""
+"""Presentation middleware exports."""
+
+from workouter_cli.presentation.middleware.error_handler import (
+    handle_cli_error,
+    handle_unexpected_error,
+)
+from workouter_cli.presentation.middleware.logging import setup_logging
+
+__all__ = ["handle_cli_error", "handle_unexpected_error", "setup_logging"]

--- a/cli/src/workouter_cli/presentation/middleware/error_handler.py
+++ b/cli/src/workouter_cli/presentation/middleware/error_handler.py
@@ -1,0 +1,46 @@
+"""Global CLI error handling helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import NoReturn
+
+import click
+from rich.console import Console
+
+from workouter_cli.domain.exceptions import CLIError, NetworkError
+
+
+def _build_error_payload(code: str, message: str, command: str) -> dict[str, object]:
+    return {
+        "success": False,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+        "metadata": {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "command": command,
+        },
+    }
+
+
+def handle_cli_error(error: CLIError, output_json: bool, command: str) -> NoReturn:
+    """Render a known CLIError and terminate with semantic code."""
+
+    if output_json:
+        payload = _build_error_payload(code=error.code, message=str(error), command=command)
+        click.echo(json.dumps(payload, separators=(",", ":"), default=str))
+    else:
+        console = Console(stderr=True)
+        console.print(f"[bold red]Error:[/bold red] {error}")
+
+    raise click.exceptions.Exit(int(error.exit_code)) from error
+
+
+def handle_unexpected_error(error: Exception, output_json: bool, command: str) -> NoReturn:
+    """Render an unexpected exception as internal/network failure."""
+
+    wrapped = NetworkError(message=str(error), code="INTERNAL_ERROR")
+    handle_cli_error(wrapped, output_json=output_json, command=command)

--- a/cli/tests/integration/test_presentation_foundation.py
+++ b/cli/tests/integration/test_presentation_foundation.py
@@ -1,0 +1,38 @@
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def test_root_help_works() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Workouter CLI" in result.output
+
+
+def test_global_flags_initialize_context(base_env: dict[str, str]) -> None:
+    runner = CliRunner(env=base_env)
+
+    result = runner.invoke(cli, ["--json", "--timeout", "42", "ping"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["message"] == "ready"
+    assert payload["data"]["timeout"] == 42
+
+
+def test_auth_error_in_json_mode_returns_exit_code_and_payload(base_env: dict[str, str]) -> None:
+    runner = CliRunner(env=base_env)
+
+    result = runner.invoke(cli, ["--json", "raise-auth"])
+
+    assert result.exit_code == 3
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "AUTH_ERROR"
+    assert payload["error"]["message"] == "Invalid API key"

--- a/cli/tests/unit/test_formatters/test_factory.py
+++ b/cli/tests/unit/test_formatters/test_factory.py
@@ -1,0 +1,15 @@
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.application.formatters.json import JsonFormatter
+from workouter_cli.application.formatters.table import TableFormatter
+
+
+def test_factory_returns_json_formatter_when_json_enabled() -> None:
+    formatter = get_formatter(output_json=True)
+
+    assert isinstance(formatter, JsonFormatter)
+
+
+def test_factory_returns_table_formatter_by_default() -> None:
+    formatter = get_formatter(output_json=False)
+
+    assert isinstance(formatter, TableFormatter)

--- a/cli/tests/unit/test_formatters/test_json_formatter.py
+++ b/cli/tests/unit/test_formatters/test_json_formatter.py
@@ -1,0 +1,16 @@
+import json
+
+from workouter_cli.application.formatters.json import JsonFormatter
+
+
+def test_json_formatter_outputs_single_line_json() -> None:
+    formatter = JsonFormatter()
+
+    output = formatter.format({"message": "ok"}, command="ping")
+
+    assert "\n" not in output
+    payload = json.loads(output)
+    assert payload["success"] is True
+    assert payload["data"] == {"message": "ok"}
+    assert payload["metadata"]["command"] == "ping"
+    assert "timestamp" in payload["metadata"]

--- a/cli/tests/unit/test_formatters/test_table_formatter.py
+++ b/cli/tests/unit/test_formatters/test_table_formatter.py
@@ -1,0 +1,21 @@
+from rich.table import Table
+
+from workouter_cli.application.formatters.table import TableFormatter
+
+
+def test_table_formatter_returns_rich_table_for_mapping() -> None:
+    formatter = TableFormatter()
+
+    output = formatter.format({"message": "ok"}, command="ping")
+
+    assert isinstance(output, Table)
+    assert output.title == "ping"
+
+
+def test_table_formatter_returns_rich_table_for_list_of_dicts() -> None:
+    formatter = TableFormatter()
+
+    output = formatter.format([{"id": "1", "name": "Bench"}], command="exercises list")
+
+    assert isinstance(output, Table)
+    assert output.title == "exercises list"

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -1,3 +1,5 @@
+import json
+
 from click.testing import CliRunner
 
 from workouter_cli.main import cli
@@ -16,7 +18,7 @@ def test_ping_exits_with_auth_code_when_api_key_missing() -> None:
     result = runner.invoke(cli, ["ping"])
 
     assert result.exit_code == 3
-    assert "WORKOUTER_API_KEY" in result.output
+    assert "WORKOUTER_API_KEY" in result.stderr
 
 
 def test_ping_exits_with_user_error_when_url_is_invalid() -> None:
@@ -29,7 +31,7 @@ def test_ping_exits_with_user_error_when_url_is_invalid() -> None:
     result = runner.invoke(cli, ["ping"])
 
     assert result.exit_code == 1
-    assert "Invalid CLI configuration" in result.output
+    assert "Invalid CLI configuration" in result.stderr
 
 
 def test_ping_with_valid_env_returns_ready() -> None:
@@ -44,4 +46,21 @@ def test_ping_with_valid_env_returns_ready() -> None:
     result = runner.invoke(cli, ["ping"])
 
     assert result.exit_code == 0
-    assert "ready" in result.output
+    assert "message" in result.output
+
+
+def test_ping_json_output_has_expected_shape() -> None:
+    runner = CliRunner(
+        env={
+            "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+            "WORKOUTER_API_KEY": "test-api-key",
+            "WORKOUTER_CLI_TIMEOUT": "30",
+            "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+        }
+    )
+    result = runner.invoke(cli, ["--json", "ping"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["message"] == "ready"


### PR DESCRIPTION
## Summary
- implement output formatter strategy with protocol, JSON formatter, Rich table formatter, and formatter factory selected by global `--json`
- add presentation dependency-injection context (`CLIContext`) and wire root CLI global options (`--json`, `--timeout`) into context initialization
- add centralized error-handling middleware that formats CLI/domain errors for JSON mode (stdout) or human mode (stderr) with semantic exit codes, plus integration and unit coverage for acceptance scenarios

## Testing
- uv run ruff check .
- uv run mypy src
- uv run pytest -q --tb=short --disable-warnings