### PR TITLE
[Exercises] Implement CRUD vertical slice through clean architecture

### DIFF
--- a/cli/src/workouter_cli/application/dto/__init__.py
+++ b/cli/src/workouter_cli/application/dto/__init__.py
@@ -1,1 +1,11 @@
 """Application DTO package."""
+
+from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
+from workouter_cli.application.dto.pagination import PaginationInput, PaginationResult
+
+__all__ = [
+    "CreateExerciseInputDTO",
+    "UpdateExerciseInputDTO",
+    "PaginationInput",
+    "PaginationResult",
+]

--- a/cli/src/workouter_cli/application/dto/exercise.py
+++ b/cli/src/workouter_cli/application/dto/exercise.py
@@ -1,0 +1,41 @@
+"""Exercise input/output DTOs."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class CreateExerciseInputDTO(BaseModel):
+    """Validated payload for creating an exercise."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    equipment: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            msg = "Exercise name must not be blank"
+            raise ValueError(msg)
+        return value
+
+
+class UpdateExerciseInputDTO(BaseModel):
+    """Validated payload for updating an exercise."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    equipment: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_optional_name_not_blank(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            msg = "Exercise name must not be blank"
+            raise ValueError(msg)
+        return value

--- a/cli/src/workouter_cli/application/dto/pagination.py
+++ b/cli/src/workouter_cli/application/dto/pagination.py
@@ -1,0 +1,25 @@
+"""Pagination DTOs."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PaginationInput(BaseModel):
+    """Common pagination input contract."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100, alias="pageSize")
+
+
+class PaginationResult(BaseModel):
+    """Pagination metadata for list outputs."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    page_size: int = Field(ge=1, le=100, alias="pageSize")
+    total_pages: int = Field(ge=0, alias="totalPages")

--- a/cli/src/workouter_cli/application/services/__init__.py
+++ b/cli/src/workouter_cli/application/services/__init__.py
@@ -1,1 +1,5 @@
 """Application services package."""
+
+from workouter_cli.application.services.exercise_service import ExerciseService
+
+__all__ = ["ExerciseService"]

--- a/cli/src/workouter_cli/application/services/exercise_service.py
+++ b/cli/src/workouter_cli/application/services/exercise_service.py
@@ -1,0 +1,33 @@
+"""Exercise application service."""
+
+from __future__ import annotations
+
+from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
+from workouter_cli.domain.entities.exercise import Exercise
+from workouter_cli.domain.repositories.exercise import ExerciseRepository
+
+
+class ExerciseService:
+    """Exercise use-cases orchestration and business defaults."""
+
+    def __init__(self, exercise_repository: ExerciseRepository) -> None:
+        self.exercise_repository = exercise_repository
+
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Exercise], dict[str, int]]:
+        return await self.exercise_repository.list(page=page, page_size=page_size)
+
+    async def get(self, exercise_id: str) -> Exercise:
+        return await self.exercise_repository.get(exercise_id)
+
+    async def create(self, payload: CreateExerciseInputDTO) -> Exercise:
+        data = payload.model_dump(exclude_none=True)
+        return await self.exercise_repository.create(data)
+
+    async def update(self, exercise_id: str, payload: UpdateExerciseInputDTO) -> Exercise:
+        data = payload.model_dump(exclude_none=True)
+        return await self.exercise_repository.update(exercise_id, data)
+
+    async def delete(self, exercise_id: str) -> bool:
+        return await self.exercise_repository.delete(exercise_id)

--- a/cli/src/workouter_cli/domain/entities/__init__.py
+++ b/cli/src/workouter_cli/domain/entities/__init__.py
@@ -1,1 +1,5 @@
 """Domain entities package."""
+
+from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+
+__all__ = ["Exercise", "ExerciseMuscleGroup", "MuscleGroup"]

--- a/cli/src/workouter_cli/domain/entities/exercise.py
+++ b/cli/src/workouter_cli/domain/entities/exercise.py
@@ -1,0 +1,32 @@
+"""Exercise domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class MuscleGroup:
+    """Exercise muscle group entity."""
+
+    id: str
+    name: str
+
+
+@dataclass(slots=True, frozen=True)
+class ExerciseMuscleGroup:
+    """Muscle group assignment for an exercise."""
+
+    muscle_group: MuscleGroup
+    role: str
+
+
+@dataclass(slots=True, frozen=True)
+class Exercise:
+    """Exercise aggregate root."""
+
+    id: str
+    name: str
+    description: str | None
+    equipment: str | None
+    muscle_groups: tuple[ExerciseMuscleGroup, ...]

--- a/cli/src/workouter_cli/domain/repositories/__init__.py
+++ b/cli/src/workouter_cli/domain/repositories/__init__.py
@@ -1,1 +1,5 @@
 """Domain repository protocols package."""
+
+from workouter_cli.domain.repositories.exercise import ExerciseRepository
+
+__all__ = ["ExerciseRepository"]

--- a/cli/src/workouter_cli/domain/repositories/exercise.py
+++ b/cli/src/workouter_cli/domain/repositories/exercise.py
@@ -1,0 +1,33 @@
+"""Exercise repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.exercise import Exercise
+
+
+class ExerciseRepository(Protocol):
+    """Persistence contract for exercises."""
+
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Exercise], dict[str, int]]:
+        """List exercises and return items with pagination metadata."""
+        ...
+
+    async def get(self, exercise_id: str) -> Exercise:
+        """Get one exercise by ID."""
+        ...
+
+    async def create(self, payload: dict[str, str | None]) -> Exercise:
+        """Create one exercise."""
+        ...
+
+    async def update(self, exercise_id: str, payload: dict[str, str | None]) -> Exercise:
+        """Update one exercise."""
+        ...
+
+    async def delete(self, exercise_id: str) -> bool:
+        """Delete one exercise."""
+        ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/__init__.py
@@ -1,1 +1,5 @@
 """GraphQL mappers package."""
+
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_exercise
+
+__all__ = ["map_exercise"]

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
@@ -1,0 +1,31 @@
+"""GraphQL response mappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+
+
+def map_exercise(data: dict[str, Any]) -> Exercise:
+    """Map GraphQL exercise payload to domain entity."""
+
+    muscle_groups = tuple(map_exercise_muscle_group(item) for item in data.get("muscleGroups", []))
+    return Exercise(
+        id=str(data["id"]),
+        name=str(data["name"]),
+        description=data.get("description"),
+        equipment=data.get("equipment"),
+        muscle_groups=muscle_groups,
+    )
+
+
+def map_exercise_muscle_group(data: dict[str, Any]) -> ExerciseMuscleGroup:
+    """Map nested exercise muscle group payload."""
+
+    muscle_group_data = data["muscleGroup"]
+    muscle_group = MuscleGroup(
+        id=str(muscle_group_data["id"]),
+        name=str(muscle_group_data["name"]),
+    )
+    return ExerciseMuscleGroup(muscle_group=muscle_group, role=str(data["role"]))

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -1,1 +1,9 @@
 """GraphQL mutations package."""
+
+from workouter_cli.infrastructure.graphql.mutations.exercise import (
+    CREATE_EXERCISE,
+    DELETE_EXERCISE,
+    UPDATE_EXERCISE,
+)
+
+__all__ = ["CREATE_EXERCISE", "UPDATE_EXERCISE", "DELETE_EXERCISE"]

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/exercise.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/exercise.py
@@ -1,0 +1,45 @@
+"""Exercise GraphQL mutations."""
+
+CREATE_EXERCISE = """
+mutation CreateExercise($input: CreateExerciseInput!) {
+  createExercise(input: $input) {
+    id
+    name
+    description
+    equipment
+    muscleGroups {
+      muscleGroup {
+        id
+        name
+      }
+      role
+    }
+  }
+}
+"""
+
+
+UPDATE_EXERCISE = """
+mutation UpdateExercise($id: UUID!, $input: UpdateExerciseInput!) {
+  updateExercise(id: $id, input: $input) {
+    id
+    name
+    description
+    equipment
+    muscleGroups {
+      muscleGroup {
+        id
+        name
+      }
+      role
+    }
+  }
+}
+"""
+
+
+DELETE_EXERCISE = """
+mutation DeleteExercise($id: UUID!) {
+  deleteExercise(id: $id)
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -1,1 +1,5 @@
 """GraphQL queries package."""
+
+from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
+
+__all__ = ["GET_EXERCISE", "LIST_EXERCISES"]

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/exercise.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/exercise.py
@@ -1,0 +1,44 @@
+"""Exercise GraphQL queries."""
+
+LIST_EXERCISES = """
+query ListExercises($pagination: PaginationInput) {
+  exercises(pagination: $pagination) {
+    items {
+      id
+      name
+      description
+      equipment
+      muscleGroups {
+        muscleGroup {
+          id
+          name
+        }
+        role
+      }
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""
+
+
+GET_EXERCISE = """
+query GetExercise($id: UUID!) {
+  exercise(id: $id) {
+    id
+    name
+    description
+    equipment
+    muscleGroups {
+      muscleGroup {
+        id
+        name
+      }
+      role
+    }
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/repositories/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/__init__.py
@@ -1,1 +1,5 @@
 """Infrastructure repository implementations package."""
+
+from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+
+__all__ = ["GraphQLExerciseRepository"]

--- a/cli/src/workouter_cli/infrastructure/repositories/exercise.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/exercise.py
@@ -1,0 +1,58 @@
+"""GraphQL-backed exercise repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.exercise import Exercise
+from workouter_cli.domain.repositories.exercise import ExerciseRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_exercise
+from workouter_cli.infrastructure.graphql.mutations.exercise import (
+    CREATE_EXERCISE,
+    DELETE_EXERCISE,
+    UPDATE_EXERCISE,
+)
+from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
+
+
+class GraphQLExerciseRepository(ExerciseRepository):
+    """Exercise repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Exercise], dict[str, int]]:
+        variables = {"pagination": {"page": page, "pageSize": page_size}}
+        result = await self.client.execute(LIST_EXERCISES, variables)
+        payload = result["exercises"]
+        items = [map_exercise(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination
+
+    async def get(self, exercise_id: str) -> Exercise:
+        result = await self.client.execute(GET_EXERCISE, {"id": exercise_id})
+        return map_exercise(result["exercise"])
+
+    async def create(self, payload: dict[str, str | None]) -> Exercise:
+        result = await self.client.execute(CREATE_EXERCISE, {"input": payload})
+        return map_exercise(result["createExercise"])
+
+    async def update(self, exercise_id: str, payload: dict[str, str | None]) -> Exercise:
+        result = await self.client.execute(
+            UPDATE_EXERCISE,
+            {
+                "id": exercise_id,
+                "input": payload,
+            },
+        )
+        return map_exercise(result["updateExercise"])
+
+    async def delete(self, exercise_id: str) -> bool:
+        result = await self.client.execute(DELETE_EXERCISE, {"id": exercise_id})
+        return bool(result["deleteExercise"])

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -6,9 +6,12 @@ import click
 from rich.console import Console
 
 from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.application.services.exercise_service import ExerciseService
 from workouter_cli.domain.exceptions import AuthError, CLIError
 from workouter_cli.infrastructure.config.loader import ConfigError, load_config
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.presentation.commands.exercises import exercises
 from workouter_cli.presentation.context import CLIContext
 from workouter_cli.presentation.middleware.error_handler import (
     handle_cli_error,
@@ -61,11 +64,14 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
         client = GraphQLClient(
             url=str(config.api_url), api_key=config.api_key, timeout=effective_timeout
         )
+        exercise_repository = GraphQLExerciseRepository(client=client)
+        exercise_service = ExerciseService(exercise_repository=exercise_repository)
         ctx.obj = CLIContext(
             config=config,
             client=client,
             output_json=output_json,
             timeout=effective_timeout,
+            exercise_service=exercise_service,
         )
     except ConfigError as error:
         code = "AUTH_ERROR" if error.exit_code == ExitCode.AUTH_ERROR else "VALIDATION_ERROR"
@@ -103,3 +109,6 @@ def raise_auth() -> None:
     """Test-only command that raises AuthError."""
 
     raise AuthError("Invalid API key")
+
+
+cli.add_command(exercises)

--- a/cli/src/workouter_cli/presentation/commands/exercises.py
+++ b/cli/src/workouter_cli/presentation/commands/exercises.py
@@ -1,0 +1,166 @@
+"""Exercises command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import asdict
+from typing import Any, TypeVar
+
+import click
+from pydantic import ValidationError as PydanticValidationError
+from rich.console import Console
+
+from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.exercise import Exercise
+from workouter_cli.domain.exceptions import ValidationError
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+def _exercise_to_payload(exercise: Exercise) -> dict[str, object]:
+    return asdict(exercise)
+
+
+@click.group(name="exercises")
+def exercises() -> None:
+    """Exercise CRUD commands."""
+
+
+@exercises.command(name="list")
+@click.option("--page", type=int, default=1, show_default=True)
+@click.option("--page-size", type=int, default=20, show_default=True)
+@click.pass_obj
+def list_exercises(ctx: CLIContext, page: int, page_size: int) -> None:
+    """List exercises."""
+
+    items: list[Exercise]
+    pagination: dict[str, int]
+    items, pagination = _run(ctx.exercise_service.list(page=page, page_size=page_size))
+    payload = {
+        "items": [_exercise_to_payload(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="exercises list")
+
+
+@exercises.command(name="get")
+@click.argument("exercise_id")
+@click.pass_obj
+def get_exercise(ctx: CLIContext, exercise_id: str) -> None:
+    """Get one exercise by ID."""
+
+    exercise: Exercise
+    exercise = _run(ctx.exercise_service.get(exercise_id))
+    _render(ctx, _exercise_to_payload(exercise), command="exercises get")
+
+
+@exercises.command(name="create")
+@click.option("--name", required=True, type=str)
+@click.option("--description", type=str, default=None)
+@click.option("--equipment", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without creating")
+@click.pass_obj
+def create_exercise(
+    ctx: CLIContext,
+    name: str,
+    description: str | None,
+    equipment: str | None,
+    dry_run: bool,
+) -> None:
+    """Create exercise."""
+
+    try:
+        dto = CreateExerciseInputDTO(name=name, description=description, equipment=equipment)
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid create payload: {message}") from error
+
+    payload = dto.model_dump(exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {"dry_run": True, "operation": "createExercise", "input": payload},
+            command="exercises create",
+        )
+        return
+
+    exercise: Exercise = _run(ctx.exercise_service.create(dto))
+    _render(ctx, _exercise_to_payload(exercise), command="exercises create")
+
+
+@exercises.command(name="update")
+@click.argument("exercise_id")
+@click.option("--name", type=str, default=None)
+@click.option("--description", type=str, default=None)
+@click.option("--equipment", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without updating")
+@click.pass_obj
+def update_exercise(
+    ctx: CLIContext,
+    exercise_id: str,
+    name: str | None,
+    description: str | None,
+    equipment: str | None,
+    dry_run: bool,
+) -> None:
+    """Update exercise."""
+
+    if name is None and description is None and equipment is None:
+        raise ValidationError("Provide at least one field to update")
+
+    try:
+        dto = UpdateExerciseInputDTO(name=name, description=description, equipment=equipment)
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid update payload: {message}") from error
+
+    payload = dto.model_dump(exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateExercise",
+                "id": exercise_id,
+                "input": payload,
+            },
+            command="exercises update",
+        )
+        return
+
+    exercise: Exercise = _run(ctx.exercise_service.update(exercise_id, dto))
+    _render(ctx, _exercise_to_payload(exercise), command="exercises update")
+
+
+@exercises.command(name="delete")
+@click.argument("exercise_id")
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def delete_exercise(ctx: CLIContext, exercise_id: str, force: bool) -> None:
+    """Delete exercise."""
+
+    if not force:
+        raise ValidationError("Use --force to delete exercise")
+
+    deleted: bool = _run(ctx.exercise_service.delete(exercise_id))
+    _render(ctx, {"id": exercise_id, "deleted": deleted}, command="exercises delete")

--- a/cli/src/workouter_cli/presentation/context.py
+++ b/cli/src/workouter_cli/presentation/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from workouter_cli.application.services.exercise_service import ExerciseService
 from workouter_cli.infrastructure.config.schema import Config
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
 
@@ -16,3 +17,4 @@ class CLIContext:
     client: GraphQLClient
     output_json: bool
     timeout: int
+    exercise_service: ExerciseService

--- a/cli/tests/integration/test_exercise_commands.py
+++ b/cli/tests/integration/test_exercise_commands.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def test_exercises_list_json_output(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock(
+        return_value={
+            "exercises": {
+                "items": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "name": "Bench Press",
+                        "description": None,
+                        "equipment": "Barbell",
+                        "muscleGroups": [],
+                    }
+                ],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(cli, ["--json", "exercises", "list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["items"][0]["name"] == "Bench Press"
+
+
+def test_exercises_create_dry_run_does_not_call_api(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock()
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        ["--json", "exercises", "create", "--name", "Bench Press", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["dry_run"] is True
+    mock_execute.assert_not_called()
+
+
+def test_exercises_delete_force_succeeds(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock(return_value={"deleteExercise": True})
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        ["--json", "exercises", "delete", "11111111-1111-1111-1111-111111111111", "--force"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["deleted"] is True

--- a/cli/tests/unit/test_exercise_dto.py
+++ b/cli/tests/unit/test_exercise_dto.py
@@ -1,0 +1,14 @@
+import pytest
+from pydantic import ValidationError
+
+from workouter_cli.application.dto.exercise import CreateExerciseInputDTO
+
+
+def test_create_exercise_dto_rejects_blank_name() -> None:
+    with pytest.raises(ValidationError):
+        CreateExerciseInputDTO(name="   ")
+
+
+def test_create_exercise_dto_rejects_name_over_200_chars() -> None:
+    with pytest.raises(ValidationError):
+        CreateExerciseInputDTO(name="x" * 201)

--- a/cli/tests/unit/test_exercise_repository.py
+++ b/cli/tests/unit/test_exercise_repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+
+
+@pytest.mark.asyncio
+async def test_repository_list_maps_items_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "exercises": {
+                "items": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "name": "Bench Press",
+                        "description": "Chest press",
+                        "equipment": "Barbell",
+                        "muscleGroups": [
+                            {
+                                "muscleGroup": {
+                                    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                                    "name": "Chest",
+                                },
+                                "role": "PRIMARY",
+                            }
+                        ],
+                    }
+                ],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLExerciseRepository(client=client)
+    items, pagination = await repository.list(page=1, page_size=20)
+
+    assert len(items) == 1
+    assert items[0].name == "Bench Press"
+    assert items[0].muscle_groups[0].muscle_group.name == "Chest"
+    assert pagination["total"] == 1
+    assert pagination["pageSize"] == 20
+    client.execute.assert_awaited_once()

--- a/cli/tests/unit/test_exercise_service.py
+++ b/cli/tests/unit/test_exercise_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.exercise_service import ExerciseService
+
+
+@pytest.mark.asyncio
+async def test_service_list_uses_default_pagination() -> None:
+    repo = AsyncMock()
+    repo.list = AsyncMock(
+        return_value=([], {"total": 0, "page": 1, "pageSize": 20, "totalPages": 0})
+    )
+    service = ExerciseService(exercise_repository=repo)
+
+    await service.list()
+
+    repo.list.assert_awaited_once_with(page=1, page_size=20)
+
+
+@pytest.mark.asyncio
+async def test_service_create_passes_serialized_payload() -> None:
+    repo = AsyncMock()
+    repo.create = AsyncMock(return_value=object())
+    service = ExerciseService(exercise_repository=repo)
+
+    from workouter_cli.application.dto.exercise import CreateExerciseInputDTO
+
+    dto = CreateExerciseInputDTO(name="Bench Press", equipment="Barbell")
+    await service.create(dto)
+
+    repo.create.assert_awaited_once_with({"name": "Bench Press", "equipment": "Barbell"})


### PR DESCRIPTION
## Summary
- Implement the exercise vertical slice end-to-end (domain entities, DTO validation, repository protocol, GraphQL queries/mutations/mappers, infrastructure repository, and application service) aligned with `DESIGN.md` and `../api/schema.graphql`.
- Add `exercises` CLI command group with `list`, `get`, `create`, `update`, and `delete` commands, including `--page/--page-size`, `--dry-run` behavior for mutating commands, and `--force` guard for delete.
- Wire exercise dependencies into CLI context/bootstrap and add comprehensive unit + integration coverage for DTO validation, repository mapping, service orchestration, and command behavior.

## Validation
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest`