### PR TITLE
[CLI] Implement schema introspection and Docker multi-stage build

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.14-slim AS base
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-install-project
+
+COPY src/ src/
+RUN uv sync --frozen --no-dev
+
+
+FROM base AS test
+
+RUN uv sync --frozen
+COPY tests/ tests/
+RUN uv run pytest tests/ -v --tb=short
+
+
+FROM python:3.14-slim AS production
+
+WORKDIR /app
+COPY --from=base /app /app
+RUN ln -s /app/.venv/bin/workouter-cli /usr/local/bin/workouter-cli
+
+ENTRYPOINT ["workouter-cli"]
+CMD ["--help"]

--- a/cli/src/workouter_cli/application/services/exercise_service.py
+++ b/cli/src/workouter_cli/application/services/exercise_service.py
@@ -14,9 +14,16 @@ class ExerciseService:
         self.exercise_repository = exercise_repository
 
     async def list(
-        self, page: int = 1, page_size: int = 20
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        muscle_group_id: str | None = None,
     ) -> tuple[list[Exercise], dict[str, int]]:
-        return await self.exercise_repository.list(page=page, page_size=page_size)
+        return await self.exercise_repository.list(
+            page=page,
+            page_size=page_size,
+            muscle_group_id=muscle_group_id,
+        )
 
     async def get(self, exercise_id: str) -> Exercise:
         return await self.exercise_repository.get(exercise_id)

--- a/cli/src/workouter_cli/domain/repositories/exercise.py
+++ b/cli/src/workouter_cli/domain/repositories/exercise.py
@@ -11,7 +11,10 @@ class ExerciseRepository(Protocol):
     """Persistence contract for exercises."""
 
     async def list(
-        self, page: int = 1, page_size: int = 20
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        muscle_group_id: str | None = None,
     ) -> tuple[list[Exercise], dict[str, int]]:
         """List exercises and return items with pagination metadata."""
         ...

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/exercise.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/exercise.py
@@ -1,8 +1,8 @@
 """Exercise GraphQL queries."""
 
 LIST_EXERCISES = """
-query ListExercises($pagination: PaginationInput) {
-  exercises(pagination: $pagination) {
+query ListExercises($pagination: PaginationInput, $muscleGroupId: UUID) {
+  exercises(pagination: $pagination, muscleGroupId: $muscleGroupId) {
     items {
       id
       name

--- a/cli/src/workouter_cli/infrastructure/repositories/exercise.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/exercise.py
@@ -21,9 +21,15 @@ class GraphQLExerciseRepository(ExerciseRepository):
         self.client = client
 
     async def list(
-        self, page: int = 1, page_size: int = 20
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        muscle_group_id: str | None = None,
     ) -> tuple[list[Exercise], dict[str, int]]:
-        variables = {"pagination": {"page": page, "pageSize": page_size}}
+        variables = {
+            "pagination": {"page": page, "pageSize": page_size},
+            "muscleGroupId": muscle_group_id,
+        }
         result = await self.client.execute(LIST_EXERCISES, variables)
         payload = result["exercises"]
         items = [map_exercise(item) for item in payload["items"]]

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 import click
 from rich.console import Console
 
@@ -44,6 +47,115 @@ class SafeGroup(click.Group):
             raise
         except Exception as error:  # pragma: no cover - defensive fallback
             handle_unexpected_error(error, output_json=output_json, command=command)
+
+
+EXAMPLE_OUTPUTS: dict[str, dict[str, Any]] = {
+    "exercises list": {
+        "success": True,
+        "data": {
+            "items": [
+                {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "name": "Bench Press",
+                    "description": "Compound chest exercise",
+                    "equipment": "Barbell",
+                    "muscle_groups": [
+                        {
+                            "muscle_group": {
+                                "id": "11111111-1111-1111-1111-111111111111",
+                                "name": "Chest",
+                            },
+                            "role": "PRIMARY",
+                        }
+                    ],
+                }
+            ],
+            "total": 42,
+            "page": 1,
+            "page_size": 20,
+            "total_pages": 3,
+        },
+    }
+}
+
+
+def _normalize_type_name(parameter_type: click.types.ParamType) -> str:
+    if isinstance(parameter_type, click.types.BoolParamType):
+        return "boolean"
+    if isinstance(parameter_type, click.types.IntParamType):
+        return "int"
+    if isinstance(parameter_type, click.types.UUIDParameterType):
+        return "UUID"
+    return parameter_type.name or parameter_type.__class__.__name__.lower()
+
+
+def _resolve_command(command_name: str) -> tuple[click.Command, str]:
+    parts = [part for part in command_name.split() if part]
+    if not parts:
+        raise click.ClickException("Command name is required")
+
+    current: click.Command | click.Group = cli
+    resolved_parts: list[str] = []
+
+    for part in parts:
+        if not isinstance(current, click.Group):
+            path = " ".join(resolved_parts)
+            raise click.ClickException(f"'{path}' has no subcommands")
+        next_command = current.commands.get(part)
+        if next_command is None:
+            raise click.ClickException(f"Unknown command: {' '.join(parts)}")
+        current = next_command
+        resolved_parts.append(part)
+
+    return current, " ".join(resolved_parts)
+
+
+def _build_schema(command_name: str) -> dict[str, Any]:
+    command, normalized_name = _resolve_command(command_name)
+    options: list[dict[str, Any]] = []
+    arguments: list[dict[str, Any]] = []
+    required_flags: list[str] = []
+
+    for parameter in command.params:
+        if isinstance(parameter, click.Option):
+            long_flags = [flag for flag in parameter.opts if flag.startswith("--")]
+            flag_name = long_flags[0] if long_flags else parameter.opts[0]
+            option_schema: dict[str, Any] = {
+                "name": flag_name,
+                "type": _normalize_type_name(parameter.type),
+                "required": parameter.required,
+                "description": parameter.help or "",
+            }
+            if parameter.default is not None:
+                option_schema["default"] = parameter.default
+            options.append(option_schema)
+            if parameter.required and flag_name.startswith("--"):
+                required_flags.append(flag_name)
+            continue
+
+        if isinstance(parameter, click.Argument):
+            arguments.append(
+                {
+                    "name": parameter.name,
+                    "type": _normalize_type_name(parameter.type),
+                    "required": parameter.required,
+                }
+            )
+
+    return {
+        "command": normalized_name,
+        "description": command.help or command.short_help or "",
+        "options": options,
+        "arguments": arguments,
+        "required_flags": required_flags,
+        "example_output": EXAMPLE_OUTPUTS.get(
+            normalized_name,
+            {
+                "success": True,
+                "data": {},
+            },
+        ),
+    }
 
 
 @click.group(cls=SafeGroup)
@@ -100,10 +212,12 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
 
 
 @cli.command(name="schema")
-def schema() -> None:
-    """Show command schema placeholder."""
+@click.argument("command_name", type=str)
+def schema(command_name: str) -> None:
+    """Show JSON schema for a command."""
 
-    click.echo('{"success": true, "data": {"message": "schema command placeholder"}}')
+    payload = _build_schema(command_name)
+    click.echo(json.dumps(payload, separators=(",", ":"), sort_keys=False))
 
 
 @cli.command(name="ping")

--- a/cli/src/workouter_cli/presentation/commands/exercises.py
+++ b/cli/src/workouter_cli/presentation/commands/exercises.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Coroutine
 from dataclasses import asdict
 from typing import Any, TypeVar
+from uuid import UUID
 
 import click
 from pydantic import ValidationError as PydanticValidationError
@@ -44,15 +45,24 @@ def exercises() -> None:
 
 
 @exercises.command(name="list")
+@click.option("--muscle-group-id", type=click.UUID, default=None)
 @click.option("--page", type=int, default=1, show_default=True)
 @click.option("--page-size", type=int, default=20, show_default=True)
 @click.pass_obj
-def list_exercises(ctx: CLIContext, page: int, page_size: int) -> None:
+def list_exercises(
+    ctx: CLIContext, muscle_group_id: UUID | None, page: int, page_size: int
+) -> None:
     """List exercises."""
 
     items: list[Exercise]
     pagination: dict[str, int]
-    items, pagination = _run(ctx.exercise_service.list(page=page, page_size=page_size))
+    items, pagination = _run(
+        ctx.exercise_service.list(
+            page=page,
+            page_size=page_size,
+            muscle_group_id=str(muscle_group_id) if muscle_group_id is not None else None,
+        )
+    )
     payload = {
         "items": [_exercise_to_payload(item) for item in items],
         "total": pagination["total"],

--- a/cli/tests/integration/test_exercise_commands.py
+++ b/cli/tests/integration/test_exercise_commands.py
@@ -51,6 +51,40 @@ def test_exercises_list_json_output(mocker) -> None:  # type: ignore[no-untyped-
     assert payload["data"]["items"][0]["name"] == "Bench Press"
 
 
+def test_exercises_list_json_accepts_muscle_group_filter(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock(
+        return_value={
+            "exercises": {
+                "items": [],
+                "total": 0,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 0,
+            }
+        }
+    )
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "exercises",
+            "list",
+            "--muscle-group-id",
+            "11111111-1111-1111-1111-111111111111",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+
+
 def test_exercises_create_dry_run_does_not_call_api(mocker) -> None:  # type: ignore[no-untyped-def]
     mock_execute = AsyncMock()
     mocker.patch(

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def test_schema_command_outputs_valid_json_for_exercises_list() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "exercises list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "exercises list"
+    assert payload["description"] == "List exercises."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--page" in options
+    assert "--muscle-group-id" in options

--- a/cli/tests/unit/test_exercise_repository.py
+++ b/cli/tests/unit/test_exercise_repository.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from workouter_cli.infrastructure.graphql.queries.exercise import LIST_EXERCISES
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
 
 
@@ -47,3 +48,32 @@ async def test_repository_list_maps_items_and_pagination() -> None:
     assert pagination["total"] == 1
     assert pagination["pageSize"] == 20
     client.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repository_list_passes_muscle_group_id_variable() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "exercises": {
+                "items": [],
+                "total": 0,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 0,
+            }
+        }
+    )
+
+    repository = GraphQLExerciseRepository(client=client)
+    await repository.list(
+        page=1, page_size=20, muscle_group_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    )
+
+    client.execute.assert_awaited_once_with(
+        LIST_EXERCISES,
+        {
+            "pagination": {"page": 1, "pageSize": 20},
+            "muscleGroupId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+    )

--- a/cli/tests/unit/test_exercise_service.py
+++ b/cli/tests/unit/test_exercise_service.py
@@ -17,7 +17,24 @@ async def test_service_list_uses_default_pagination() -> None:
 
     await service.list()
 
-    repo.list.assert_awaited_once_with(page=1, page_size=20)
+    repo.list.assert_awaited_once_with(page=1, page_size=20, muscle_group_id=None)
+
+
+@pytest.mark.asyncio
+async def test_service_list_passes_muscle_group_filter() -> None:
+    repo = AsyncMock()
+    repo.list = AsyncMock(
+        return_value=([], {"total": 0, "page": 1, "pageSize": 20, "totalPages": 0})
+    )
+    service = ExerciseService(exercise_repository=repo)
+
+    await service.list(muscle_group_id="11111111-1111-1111-1111-111111111111")
+
+    repo.list.assert_awaited_once_with(
+        page=1,
+        page_size=20,
+        muscle_group_id="11111111-1111-1111-1111-111111111111",
+    )
 
 
 @pytest.mark.asyncio

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -64,3 +64,25 @@ def test_ping_json_output_has_expected_shape() -> None:
     payload = json.loads(result.output.strip())
     assert payload["success"] is True
     assert payload["data"]["message"] == "ready"
+
+
+def test_schema_exercises_list_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "exercises list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "exercises list"
+    assert payload["description"] == "List exercises."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--page" in option_names
+    assert "--muscle-group-id" in option_names
+
+
+def test_schema_unknown_command_fails() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "nope cmd"])
+
+    assert result.exit_code != 0
+    assert "Unknown command" in result.output


### PR DESCRIPTION
## Summary
- implement `workouter-cli schema \"<command>\"` with Click-based introspection that returns pure JSON including description, options, required flags/arguments, and example output
- add `--muscle-group-id` support to `exercises list` through presentation, service, repository contract, GraphQL query, and repository variables
- add coverage for schema and exercise filter flows, and add a multi-stage `Dockerfile` using `python:3.14-slim` + `uv` with a dedicated test stage running `pytest`

## Validation
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q --tb=short --disable-warnings`

Closes #14