### PR TITLE
[CLI][Workout] Close workflow command parity gaps

### DIFF
--- a/cli/src/workouter_cli/application/services/session_service.py
+++ b/cli/src/workouter_cli/application/services/session_service.py
@@ -21,6 +21,17 @@ class SessionService:
     async def complete(self, session_id: str) -> Session:
         return await self.session_repository.complete(session_id)
 
+    async def update(self, session_id: str, payload: dict[str, str | None]) -> Session:
+        return await self.session_repository.update(session_id, payload)
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Session], dict[str, int]]:
+        return await self.session_repository.list(page=page, page_size=page_size, status=status)
+
     async def log_set(
         self, set_id: str, payload: dict[str, int | float | str | None]
     ) -> SessionSet:

--- a/cli/src/workouter_cli/domain/repositories/session.py
+++ b/cli/src/workouter_cli/domain/repositories/session.py
@@ -22,6 +22,19 @@ class SessionRepository(Protocol):
         """Complete one session."""
         ...
 
+    async def update(self, session_id: str, payload: dict[str, str | None]) -> Session:
+        """Update one session."""
+        ...
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Session], dict[str, int]]:
+        """List sessions and return items with pagination metadata."""
+        ...
+
     async def log_set(
         self, set_id: str, payload: dict[str, int | float | str | None]
     ) -> SessionSet:

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -10,6 +10,7 @@ from workouter_cli.infrastructure.graphql.mutations.session import (
     CREATE_SESSION,
     LOG_SET_RESULT,
     START_SESSION,
+    UPDATE_SESSION,
 )
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "CREATE_SESSION",
     "START_SESSION",
     "COMPLETE_SESSION",
+    "UPDATE_SESSION",
     "LOG_SET_RESULT",
 ]

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/session.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/session.py
@@ -123,6 +123,47 @@ mutation CompleteSession($id: UUID!) {
 """
 
 
+UPDATE_SESSION = """
+mutation UpdateSession($id: UUID!, $input: UpdateSessionInput!) {
+  updateSession(id: $id, input: $input) {
+    id
+    plannedSessionId
+    mesocycleId
+    routineId
+    status
+    startedAt
+    completedAt
+    notes
+    exercises {
+      id
+      exercise {
+        id
+        name
+      }
+      order
+      supersetGroup
+      restSeconds
+      notes
+      sets {
+        id
+        setNumber
+        setType
+        targetReps
+        targetRir
+        targetWeightKg
+        actualReps
+        actualRir
+        actualWeightKg
+        weightReductionPct
+        restSeconds
+        performedAt
+      }
+    }
+  }
+}
+"""
+
+
 LOG_SET_RESULT = """
 mutation LogSetResult($setId: UUID!, $input: LogSetResultInput!) {
   logSetResult(setId: $setId, input: $input) {

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -2,5 +2,6 @@
 
 from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
 from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
+from workouter_cli.infrastructure.graphql.queries.session import LIST_SESSIONS
 
-__all__ = ["GET_EXERCISE", "LIST_EXERCISES", "CALENDAR_DAY"]
+__all__ = ["GET_EXERCISE", "LIST_EXERCISES", "CALENDAR_DAY", "LIST_SESSIONS"]

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/session.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/session.py
@@ -1,0 +1,47 @@
+"""Session GraphQL queries."""
+
+LIST_SESSIONS = """
+query ListSessions($pagination: PaginationInput, $status: SessionStatus) {
+  sessions(pagination: $pagination, status: $status) {
+    items {
+      id
+      plannedSessionId
+      mesocycleId
+      routineId
+      status
+      startedAt
+      completedAt
+      notes
+      exercises {
+        id
+        exercise {
+          id
+          name
+        }
+        order
+        supersetGroup
+        restSeconds
+        notes
+        sets {
+          id
+          setNumber
+          setType
+          targetReps
+          targetRir
+          targetWeightKg
+          actualReps
+          actualRir
+          actualWeightKg
+          weightReductionPct
+          restSeconds
+          performedAt
+        }
+      }
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/repositories/session.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/session.py
@@ -14,7 +14,9 @@ from workouter_cli.infrastructure.graphql.mutations.session import (
     CREATE_SESSION,
     LOG_SET_RESULT,
     START_SESSION,
+    UPDATE_SESSION,
 )
+from workouter_cli.infrastructure.graphql.queries.session import LIST_SESSIONS
 
 
 class GraphQLSessionRepository(SessionRepository):
@@ -34,6 +36,31 @@ class GraphQLSessionRepository(SessionRepository):
     async def complete(self, session_id: str) -> Session:
         result = await self.client.execute(COMPLETE_SESSION, {"id": session_id})
         return map_session(result["completeSession"])
+
+    async def update(self, session_id: str, payload: dict[str, str | None]) -> Session:
+        result = await self.client.execute(UPDATE_SESSION, {"id": session_id, "input": payload})
+        return map_session(result["updateSession"])
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Session], dict[str, int]]:
+        variables = {
+            "pagination": {"page": page, "pageSize": page_size},
+            "status": status,
+        }
+        result = await self.client.execute(LIST_SESSIONS, variables)
+        payload = result["sessions"]
+        items = [map_session(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination
 
     async def log_set(
         self, set_id: str, payload: dict[str, int | float | str | None]

--- a/cli/src/workouter_cli/presentation/commands/workout.py
+++ b/cli/src/workouter_cli/presentation/commands/workout.py
@@ -34,6 +34,18 @@ def _render(ctx: CLIContext, payload: object, command: str) -> None:
         Console().print(rendered)
 
 
+def _resolve_active_session_id(ctx: CLIContext, session_id: str | None) -> str:
+    if session_id is not None:
+        return session_id
+
+    sessions, _ = _run(ctx.session_service.list(page=1, page_size=2, status="IN_PROGRESS"))
+    if not sessions:
+        raise ValidationError("No active session found; provide --session-id")
+    if len(sessions) > 1:
+        raise ValidationError("Multiple active sessions found; provide --session-id")
+    return sessions[0].id
+
+
 @click.group(name="workout")
 def workout() -> None:
     """High-level workout workflow commands."""
@@ -55,6 +67,7 @@ def workout_today(ctx: CLIContext, date_str: datetime | None) -> None:
 @click.option("--mesocycle-id", type=str, default=None)
 @click.option("--notes", type=str, default=None)
 @click.option("--date", "date_str", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without creating")
 @click.pass_obj
 def workout_start(
     ctx: CLIContext,
@@ -62,8 +75,35 @@ def workout_start(
     mesocycle_id: str | None,
     notes: str | None,
     date_str: datetime | None,
+    dry_run: bool,
 ) -> None:
     """Start a workout session from today's plan or explicit routine."""
+
+    if dry_run:
+        if routine_id is None:
+            raise ValidationError("Missing required flag for dry-run: --routine-id")
+        payload: dict[str, object] = {
+            "dry_run": True,
+            "operations": [
+                {
+                    "operation": "createSession",
+                    "input": {
+                        "plannedSessionId": None,
+                        "mesocycleId": mesocycle_id,
+                        "routineId": routine_id,
+                        "notes": notes,
+                    },
+                },
+                {
+                    "operation": "startSession",
+                    "input": {"id": "$createSession.id"},
+                },
+            ],
+        }
+        if date_str is not None:
+            payload["date"] = date_str.date().isoformat()
+        _render(ctx, payload, command="workout start")
+        return
 
     target_date = date_str.date() if date_str is not None else None
     session: Session = _run(
@@ -94,14 +134,14 @@ def workout_log(
 ) -> None:
     """Log set results for an active workout session."""
 
-    if session_id is None:
-        raise ValidationError("Missing required flag: --session-id")
     if set_id is None:
         raise ValidationError("Missing required flag: --set-id")
     if reps is None:
         raise ValidationError("Missing required flag: --reps")
     if weight is None:
         raise ValidationError("Missing required flag: --weight")
+
+    resolved_session_id = _resolve_active_session_id(ctx, session_id)
 
     payload: dict[str, int | float | str | None] = {
         "actualReps": reps,
@@ -112,7 +152,7 @@ def workout_log(
     _render(
         ctx,
         {
-            "session_id": session_id,
+            "session_id": resolved_session_id,
             "set": asdict(logged),
         },
         command="workout log",
@@ -120,10 +160,14 @@ def workout_log(
 
 
 @workout.command(name="complete")
-@click.option("--session-id", type=str, required=True)
+@click.option("--session-id", type=str, default=None)
+@click.option("--notes", type=str, default=None)
 @click.pass_obj
-def workout_complete(ctx: CLIContext, session_id: str) -> None:
+def workout_complete(ctx: CLIContext, session_id: str | None, notes: str | None) -> None:
     """Complete a workout session."""
 
-    session: Session = _run(ctx.session_service.complete(session_id))
+    resolved_session_id = _resolve_active_session_id(ctx, session_id)
+    if notes is not None:
+        _run(ctx.session_service.update(resolved_session_id, {"notes": notes}))
+    session: Session = _run(ctx.session_service.complete(resolved_session_id))
     _render(ctx, asdict(session), command="workout complete")

--- a/cli/tests/integration/test_workout_commands.py
+++ b/cli/tests/integration/test_workout_commands.py
@@ -78,6 +78,41 @@ def test_workout_start_runs_calendar_create_start_in_order(mocker) -> None:  # t
     assert calls == ["calendarDay", "createSession", "startSession"]
 
 
+def test_workout_start_dry_run_does_not_call_api(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock()
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "workout",
+            "start",
+            "--routine-id",
+            "66666666-6666-6666-6666-666666666666",
+            "--mesocycle-id",
+            "55555555-5555-5555-5555-555555555555",
+            "--notes",
+            "Leg day",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["dry_run"] is True
+    assert payload["data"]["operations"][0]["operation"] == "createSession"
+    assert payload["data"]["operations"][0]["input"]["routineId"] == (
+        "66666666-6666-6666-6666-666666666666"
+    )
+    mock_execute.assert_not_called()
+
+
 def test_workout_log_without_required_flags_returns_validation_error_json(
     mocker,
 ) -> None:  # type: ignore[no-untyped-def]
@@ -94,5 +129,164 @@ def test_workout_log_without_required_flags_returns_validation_error_json(
     payload = json.loads(result.output.strip())
     assert payload["success"] is False
     assert payload["error"]["code"] == "VALIDATION_ERROR"
-    assert "--session-id" in payload["error"]["message"]
+    assert "--set-id" in payload["error"]["message"]
     mock_execute.assert_not_called()
+
+
+def test_workout_log_autodetects_single_active_session(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "sessions(" in query:
+            calls.append("sessions")
+            return {
+                "sessions": {
+                    "items": [_session_payload("IN_PROGRESS")],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 2,
+                    "totalPages": 1,
+                }
+            }
+        if "logSetResult" in query:
+            calls.append("logSetResult")
+            return {
+                "logSetResult": {
+                    "id": "99999999-9999-9999-9999-999999999999",
+                    "setNumber": 1,
+                    "setType": "WORKING",
+                    "targetReps": 10,
+                    "targetRir": 2,
+                    "targetWeightKg": 80.0,
+                    "actualReps": 10,
+                    "actualRir": 1,
+                    "actualWeightKg": 82.5,
+                    "weightReductionPct": None,
+                    "restSeconds": 120,
+                    "performedAt": "2026-01-01T10:10:00Z",
+                }
+            }
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "workout",
+            "log",
+            "--set-id",
+            "99999999-9999-9999-9999-999999999999",
+            "--reps",
+            "10",
+            "--weight",
+            "82.5",
+            "--rir",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["session_id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["data"]["set"]["actual_reps"] == 10
+    assert calls == ["sessions", "logSetResult"]
+
+
+def test_workout_log_autodetect_errors_on_multiple_active_sessions(
+    mocker,
+) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock(
+        return_value={
+            "sessions": {
+                "items": [
+                    _session_payload("IN_PROGRESS"),
+                    {
+                        **_session_payload("IN_PROGRESS"),
+                        "id": "22222222-2222-2222-2222-222222222222",
+                    },
+                ],
+                "total": 2,
+                "page": 1,
+                "pageSize": 2,
+                "totalPages": 1,
+            }
+        }
+    )
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "workout",
+            "log",
+            "--set-id",
+            "99999999-9999-9999-9999-999999999999",
+            "--reps",
+            "10",
+            "--weight",
+            "82.5",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "VALIDATION_ERROR"
+    assert "Multiple active sessions" in payload["error"]["message"]
+    mock_execute.assert_awaited_once()
+
+
+def test_workout_complete_with_notes_updates_then_completes(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "sessions(" in query:
+            calls.append("sessions")
+            return {
+                "sessions": {
+                    "items": [_session_payload("IN_PROGRESS")],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 2,
+                    "totalPages": 1,
+                }
+            }
+        if "updateSession" in query:
+            calls.append("updateSession")
+            payload = _session_payload("IN_PROGRESS")
+            payload["notes"] = "Strong day"
+            return {"updateSession": payload}
+        if "completeSession" in query:
+            calls.append("completeSession")
+            payload = _session_payload("COMPLETED")
+            payload["completedAt"] = "2026-01-01T11:00:00Z"
+            payload["notes"] = "Strong day"
+            return {"completeSession": payload}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(cli, ["--json", "workout", "complete", "--notes", "Strong day"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["status"] == "COMPLETED"
+    assert payload["data"]["notes"] == "Strong day"
+    assert calls == ["sessions", "updateSession", "completeSession"]

--- a/cli/tests/unit/test_session_repository.py
+++ b/cli/tests/unit/test_session_repository.py
@@ -48,3 +48,45 @@ async def test_repository_complete_maps_session() -> None:
     assert session.status == "COMPLETED"
     assert session.completed_at == "2026-01-01T11:00:00Z"
     client.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repository_update_maps_session() -> None:
+    payload = _session_payload("IN_PROGRESS")
+    payload["notes"] = "Solid session"
+
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updateSession": payload})
+
+    repository = GraphQLSessionRepository(client=client)
+    session = await repository.update(
+        "11111111-1111-1111-1111-111111111111", {"notes": "Solid session"}
+    )
+
+    assert session.notes == "Solid session"
+    client.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repository_list_maps_sessions_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "sessions": {
+                "items": [_session_payload("IN_PROGRESS")],
+                "total": 1,
+                "page": 1,
+                "pageSize": 2,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLSessionRepository(client=client)
+    items, pagination = await repository.list(page=1, page_size=2, status="IN_PROGRESS")
+
+    assert len(items) == 1
+    assert items[0].status == "IN_PROGRESS"
+    assert pagination["total"] == 1
+    assert pagination["pageSize"] == 2
+    client.execute.assert_awaited_once()

--- a/cli/tests/unit/test_session_service.py
+++ b/cli/tests/unit/test_session_service.py
@@ -45,3 +45,31 @@ async def test_session_service_complete_delegates_to_repository(mocker) -> None:
 
     assert result.status == "COMPLETED"
     repository.complete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_session_service_update_delegates_to_repository(mocker) -> None:  # type: ignore[no-untyped-def]
+    updated = _session("IN_PROGRESS")
+    repository = mocker.Mock()
+    repository.update = AsyncMock(return_value=updated)
+    service = SessionService(session_repository=repository)
+
+    result = await service.update("11111111-1111-1111-1111-111111111111", {"notes": "Great"})
+
+    assert result.status == "IN_PROGRESS"
+    repository.update.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111", {"notes": "Great"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_service_list_delegates_to_repository(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.list = AsyncMock(return_value=([_session("IN_PROGRESS")], {"total": 1}))
+    service = SessionService(session_repository=repository)
+
+    items, pagination = await service.list(page=1, page_size=2, status="IN_PROGRESS")
+
+    assert len(items) == 1
+    assert pagination["total"] == 1
+    repository.list.assert_awaited_once_with(page=1, page_size=2, status="IN_PROGRESS")


### PR DESCRIPTION
## Summary
- add `workout start --dry-run` that validates input and returns planned mutation payload without calling the API
- add active-session auto-detection for `workout log` and `workout complete` (uses active session when exactly one is in progress, errors when multiple/none)
- add `--notes` support for `workout complete` by updating notes before completion, and extend session repository/service with `list` and `update`
- add integration and unit tests covering dry-run behavior, auto-detection success/failure, and completion with notes

## Validation
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest tests/integration/test_workout_commands.py -q --no-cov`
- `uv run pytest tests/unit/test_session_service.py tests/unit/test_session_repository.py -q --no-cov`

Closes #23