### PR TITLE
[CLI][Sessions] Implement sessions command group

### DIFF
--- a/cli/src/workouter_cli/application/services/session_service.py
+++ b/cli/src/workouter_cli/application/services/session_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from workouter_cli.domain.entities.session import Session, SessionSet
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 from workouter_cli.domain.repositories.session import SessionRepository
 
 
@@ -29,8 +29,46 @@ class SessionService:
         page: int = 1,
         page_size: int = 20,
         status: str | None = None,
+        mesocycle_id: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> tuple[list[Session], dict[str, int]]:
-        return await self.session_repository.list(page=page, page_size=page_size, status=status)
+        return await self.session_repository.list(
+            page=page,
+            page_size=page_size,
+            status=status,
+            mesocycle_id=mesocycle_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def get(self, session_id: str) -> Session:
+        return await self.session_repository.get(session_id)
+
+    async def delete(self, session_id: str) -> bool:
+        return await self.session_repository.delete(session_id)
+
+    async def add_exercise(self, session_id: str, payload: dict[str, object]) -> Session:
+        return await self.session_repository.add_exercise(session_id, payload)
+
+    async def update_exercise(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        return await self.session_repository.update_exercise(session_exercise_id, payload)
+
+    async def remove_exercise(self, session_exercise_id: str) -> bool:
+        return await self.session_repository.remove_exercise(session_exercise_id)
+
+    async def add_set(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        return await self.session_repository.add_set(session_exercise_id, payload)
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> SessionSet:
+        return await self.session_repository.update_set(set_id, payload)
+
+    async def remove_set(self, set_id: str) -> bool:
+        return await self.session_repository.remove_set(set_id)
 
     async def log_set(
         self, set_id: str, payload: dict[str, int | float | str | None]

--- a/cli/src/workouter_cli/domain/repositories/session.py
+++ b/cli/src/workouter_cli/domain/repositories/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from workouter_cli.domain.entities.session import Session, SessionSet
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
 
 class SessionRepository(Protocol):
@@ -31,8 +31,47 @@ class SessionRepository(Protocol):
         page: int = 1,
         page_size: int = 20,
         status: str | None = None,
+        mesocycle_id: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> tuple[list[Session], dict[str, int]]:
         """List sessions and return items with pagination metadata."""
+        ...
+
+    async def get(self, session_id: str) -> Session:
+        """Get one session by ID."""
+        ...
+
+    async def delete(self, session_id: str) -> bool:
+        """Delete one session."""
+        ...
+
+    async def add_exercise(self, session_id: str, payload: dict[str, object]) -> Session:
+        """Add one exercise to a session."""
+        ...
+
+    async def update_exercise(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        """Update one session exercise and return its latest state."""
+        ...
+
+    async def remove_exercise(self, session_exercise_id: str) -> bool:
+        """Remove one exercise from a session."""
+        ...
+
+    async def add_set(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        """Add one set to a session exercise and return latest set."""
+        ...
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> SessionSet:
+        """Update one session set."""
+        ...
+
+    async def remove_set(self, set_id: str) -> bool:
+        """Remove one set from a session exercise."""
         ...
 
     async def log_set(

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -6,11 +6,18 @@ from workouter_cli.infrastructure.graphql.mutations.exercise import (
     UPDATE_EXERCISE,
 )
 from workouter_cli.infrastructure.graphql.mutations.session import (
+    ADD_SESSION_EXERCISE,
+    ADD_SESSION_SET,
     COMPLETE_SESSION,
     CREATE_SESSION,
+    DELETE_SESSION,
     LOG_SET_RESULT,
+    REMOVE_SESSION_EXERCISE,
+    REMOVE_SESSION_SET,
     START_SESSION,
+    UPDATE_SESSION_EXERCISE,
     UPDATE_SESSION,
+    UPDATE_SESSION_SET,
 )
 
 __all__ = [
@@ -21,5 +28,12 @@ __all__ = [
     "START_SESSION",
     "COMPLETE_SESSION",
     "UPDATE_SESSION",
+    "DELETE_SESSION",
+    "ADD_SESSION_EXERCISE",
+    "UPDATE_SESSION_EXERCISE",
+    "REMOVE_SESSION_EXERCISE",
+    "ADD_SESSION_SET",
+    "UPDATE_SESSION_SET",
+    "REMOVE_SESSION_SET",
     "LOG_SET_RESULT",
 ]

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/session.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/session.py
@@ -1,184 +1,172 @@
 """Session GraphQL mutations."""
 
-CREATE_SESSION = """
+from workouter_cli.infrastructure.graphql.queries.session import SESSION_FIELDS
+
+SESSION_EXERCISE_FIELDS = """
+id
+exercise {
+  id
+  name
+}
+order
+supersetGroup
+restSeconds
+notes
+sets {
+  id
+  setNumber
+  setType
+  targetReps
+  targetRir
+  targetWeightKg
+  actualReps
+  actualRir
+  actualWeightKg
+  weightReductionPct
+  restSeconds
+  performedAt
+}
+"""
+
+SESSION_SET_FIELDS = """
+id
+setNumber
+setType
+targetReps
+targetRir
+targetWeightKg
+actualReps
+actualRir
+actualWeightKg
+weightReductionPct
+restSeconds
+performedAt
+"""
+
+CREATE_SESSION = (
+    """
 mutation CreateSession($input: CreateSessionInput!) {
   createSession(input: $input) {
-    id
-    plannedSessionId
-    mesocycleId
-    routineId
-    status
-    startedAt
-    completedAt
-    notes
-    exercises {
-      id
-      exercise {
-        id
-        name
-      }
-      order
-      supersetGroup
-      restSeconds
-      notes
-      sets {
-        id
-        setNumber
-        setType
-        targetReps
-        targetRir
-        targetWeightKg
-        actualReps
-        actualRir
-        actualWeightKg
-        weightReductionPct
-        restSeconds
-        performedAt
-      }
-    }
+    %s
   }
 }
 """
+    % SESSION_FIELDS
+)
 
 
-START_SESSION = """
+START_SESSION = (
+    """
 mutation StartSession($id: UUID!) {
   startSession(id: $id) {
-    id
-    plannedSessionId
-    mesocycleId
-    routineId
-    status
-    startedAt
-    completedAt
-    notes
-    exercises {
-      id
-      exercise {
-        id
-        name
-      }
-      order
-      supersetGroup
-      restSeconds
-      notes
-      sets {
-        id
-        setNumber
-        setType
-        targetReps
-        targetRir
-        targetWeightKg
-        actualReps
-        actualRir
-        actualWeightKg
-        weightReductionPct
-        restSeconds
-        performedAt
-      }
-    }
+    %s
   }
 }
 """
+    % SESSION_FIELDS
+)
 
 
-COMPLETE_SESSION = """
+COMPLETE_SESSION = (
+    """
 mutation CompleteSession($id: UUID!) {
   completeSession(id: $id) {
-    id
-    plannedSessionId
-    mesocycleId
-    routineId
-    status
-    startedAt
-    completedAt
-    notes
-    exercises {
-      id
-      exercise {
-        id
-        name
-      }
-      order
-      supersetGroup
-      restSeconds
-      notes
-      sets {
-        id
-        setNumber
-        setType
-        targetReps
-        targetRir
-        targetWeightKg
-        actualReps
-        actualRir
-        actualWeightKg
-        weightReductionPct
-        restSeconds
-        performedAt
-      }
-    }
+    %s
   }
 }
 """
+    % SESSION_FIELDS
+)
 
 
-UPDATE_SESSION = """
+UPDATE_SESSION = (
+    """
 mutation UpdateSession($id: UUID!, $input: UpdateSessionInput!) {
   updateSession(id: $id, input: $input) {
-    id
-    plannedSessionId
-    mesocycleId
-    routineId
-    status
-    startedAt
-    completedAt
-    notes
-    exercises {
-      id
-      exercise {
-        id
-        name
-      }
-      order
-      supersetGroup
-      restSeconds
-      notes
-      sets {
-        id
-        setNumber
-        setType
-        targetReps
-        targetRir
-        targetWeightKg
-        actualReps
-        actualRir
-        actualWeightKg
-        weightReductionPct
-        restSeconds
-        performedAt
-      }
-    }
+    %s
   }
+}
+"""
+    % SESSION_FIELDS
+)
+
+
+DELETE_SESSION = """
+mutation DeleteSession($id: UUID!) {
+  deleteSession(id: $id)
 }
 """
 
 
-LOG_SET_RESULT = """
+ADD_SESSION_EXERCISE = (
+    """
+mutation AddSessionExercise($sessionId: UUID!, $input: AddSessionExerciseInput!) {
+  addSessionExercise(sessionId: $sessionId, input: $input) {
+    %s
+  }
+}
+"""
+    % SESSION_FIELDS
+)
+
+
+UPDATE_SESSION_EXERCISE = (
+    """
+mutation UpdateSessionExercise($id: UUID!, $input: UpdateSessionExerciseInput!) {
+  updateSessionExercise(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % SESSION_EXERCISE_FIELDS
+)
+
+
+REMOVE_SESSION_EXERCISE = """
+mutation RemoveSessionExercise($id: UUID!) {
+  removeSessionExercise(id: $id)
+}
+"""
+
+
+ADD_SESSION_SET = (
+    """
+mutation AddSessionSet($sessionExerciseId: UUID!, $input: AddSessionSetInput!) {
+  addSessionSet(sessionExerciseId: $sessionExerciseId, input: $input) {
+    %s
+  }
+}
+"""
+    % SESSION_EXERCISE_FIELDS
+)
+
+
+UPDATE_SESSION_SET = (
+    """
+mutation UpdateSessionSet($id: UUID!, $input: UpdateSessionSetInput!) {
+  updateSessionSet(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % SESSION_SET_FIELDS
+)
+
+
+REMOVE_SESSION_SET = """
+mutation RemoveSessionSet($id: UUID!) {
+  removeSessionSet(id: $id)
+}
+"""
+
+
+LOG_SET_RESULT = (
+    """
 mutation LogSetResult($setId: UUID!, $input: LogSetResultInput!) {
   logSetResult(setId: $setId, input: $input) {
-    id
-    setNumber
-    setType
-    targetReps
-    targetRir
-    targetWeightKg
-    actualReps
-    actualRir
-    actualWeightKg
-    weightReductionPct
-    restSeconds
-    performedAt
+    %s
   }
 }
 """
+    % SESSION_SET_FIELDS
+)

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -2,6 +2,6 @@
 
 from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
 from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
-from workouter_cli.infrastructure.graphql.queries.session import LIST_SESSIONS
+from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 
-__all__ = ["GET_EXERCISE", "LIST_EXERCISES", "CALENDAR_DAY", "LIST_SESSIONS"]
+__all__ = ["GET_EXERCISE", "LIST_EXERCISES", "CALENDAR_DAY", "LIST_SESSIONS", "GET_SESSION"]

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/session.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/session.py
@@ -1,42 +1,59 @@
 """Session GraphQL queries."""
 
-LIST_SESSIONS = """
-query ListSessions($pagination: PaginationInput, $status: SessionStatus) {
-  sessions(pagination: $pagination, status: $status) {
+SESSION_FIELDS = """
+id
+plannedSessionId
+mesocycleId
+routineId
+status
+startedAt
+completedAt
+notes
+exercises {
+  id
+  exercise {
+    id
+    name
+  }
+  order
+  supersetGroup
+  restSeconds
+  notes
+  sets {
+    id
+    setNumber
+    setType
+    targetReps
+    targetRir
+    targetWeightKg
+    actualReps
+    actualRir
+    actualWeightKg
+    weightReductionPct
+    restSeconds
+    performedAt
+  }
+}
+"""
+
+LIST_SESSIONS = (
+    """
+query ListSessions(
+  $pagination: PaginationInput
+  $status: SessionStatus
+  $mesocycleId: UUID
+  $dateFrom: Date
+  $dateTo: Date
+) {
+  sessions(
+    pagination: $pagination
+    status: $status
+    mesocycleId: $mesocycleId
+    dateFrom: $dateFrom
+    dateTo: $dateTo
+  ) {
     items {
-      id
-      plannedSessionId
-      mesocycleId
-      routineId
-      status
-      startedAt
-      completedAt
-      notes
-      exercises {
-        id
-        exercise {
-          id
-          name
-        }
-        order
-        supersetGroup
-        restSeconds
-        notes
-        sets {
-          id
-          setNumber
-          setType
-          targetReps
-          targetRir
-          targetWeightKg
-          actualReps
-          actualRir
-          actualWeightKg
-          weightReductionPct
-          restSeconds
-          performedAt
-        }
-      }
+      %s
     }
     total
     page
@@ -45,3 +62,16 @@ query ListSessions($pagination: PaginationInput, $status: SessionStatus) {
   }
 }
 """
+    % SESSION_FIELDS
+)
+
+GET_SESSION = (
+    """
+query GetSession($id: UUID!) {
+  session(id: $id) {
+    %s
+  }
+}
+"""
+    % SESSION_FIELDS
+)

--- a/cli/src/workouter_cli/infrastructure/repositories/session.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/session.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
-from workouter_cli.domain.entities.session import Session, SessionSet
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 from workouter_cli.domain.repositories.session import SessionRepository
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
 from workouter_cli.infrastructure.graphql.mappers.response_mapper import (
     map_session,
+    map_session_exercise,
     map_session_set,
 )
 from workouter_cli.infrastructure.graphql.mutations.session import (
+    ADD_SESSION_EXERCISE,
+    ADD_SESSION_SET,
     COMPLETE_SESSION,
     CREATE_SESSION,
+    DELETE_SESSION,
     LOG_SET_RESULT,
+    REMOVE_SESSION_EXERCISE,
+    REMOVE_SESSION_SET,
     START_SESSION,
+    UPDATE_SESSION_EXERCISE,
     UPDATE_SESSION,
+    UPDATE_SESSION_SET,
 )
-from workouter_cli.infrastructure.graphql.queries.session import LIST_SESSIONS
+from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 
 
 class GraphQLSessionRepository(SessionRepository):
@@ -46,10 +54,16 @@ class GraphQLSessionRepository(SessionRepository):
         page: int = 1,
         page_size: int = 20,
         status: str | None = None,
+        mesocycle_id: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
     ) -> tuple[list[Session], dict[str, int]]:
         variables = {
             "pagination": {"page": page, "pageSize": page_size},
             "status": status,
+            "mesocycleId": mesocycle_id,
+            "dateFrom": date_from,
+            "dateTo": date_to,
         }
         result = await self.client.execute(LIST_SESSIONS, variables)
         payload = result["sessions"]
@@ -61,6 +75,54 @@ class GraphQLSessionRepository(SessionRepository):
             "totalPages": int(payload["totalPages"]),
         }
         return items, pagination
+
+    async def get(self, session_id: str) -> Session:
+        result = await self.client.execute(GET_SESSION, {"id": session_id})
+        return map_session(result["session"])
+
+    async def delete(self, session_id: str) -> bool:
+        result = await self.client.execute(DELETE_SESSION, {"id": session_id})
+        return bool(result["deleteSession"])
+
+    async def add_exercise(self, session_id: str, payload: dict[str, object]) -> Session:
+        result = await self.client.execute(
+            ADD_SESSION_EXERCISE,
+            {"sessionId": session_id, "input": payload},
+        )
+        return map_session(result["addSessionExercise"])
+
+    async def update_exercise(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        result = await self.client.execute(
+            UPDATE_SESSION_EXERCISE,
+            {"id": session_exercise_id, "input": payload},
+        )
+        return map_session_exercise(result["updateSessionExercise"])
+
+    async def remove_exercise(self, session_exercise_id: str) -> bool:
+        result = await self.client.execute(REMOVE_SESSION_EXERCISE, {"id": session_exercise_id})
+        return bool(result["removeSessionExercise"])
+
+    async def add_set(
+        self, session_exercise_id: str, payload: dict[str, object]
+    ) -> SessionExercise:
+        result = await self.client.execute(
+            ADD_SESSION_SET,
+            {"sessionExerciseId": session_exercise_id, "input": payload},
+        )
+        return map_session_exercise(result["addSessionSet"])
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> SessionSet:
+        result = await self.client.execute(
+            UPDATE_SESSION_SET,
+            {"id": set_id, "input": payload},
+        )
+        return map_session_set(result["updateSessionSet"])
+
+    async def remove_set(self, set_id: str) -> bool:
+        result = await self.client.execute(REMOVE_SESSION_SET, {"id": set_id})
+        return bool(result["removeSessionSet"])
 
     async def log_set(
         self, set_id: str, payload: dict[str, int | float | str | None]

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -20,6 +20,7 @@ from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRe
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.presentation.commands.exercises import exercises
+from workouter_cli.presentation.commands.sessions import sessions
 from workouter_cli.presentation.commands.workout import workout
 from workouter_cli.presentation.context import CLIContext
 from workouter_cli.presentation.middleware.error_handler import (
@@ -243,4 +244,5 @@ def raise_auth() -> None:
 
 
 cli.add_command(exercises)
+cli.add_command(sessions)
 cli.add_command(workout)

--- a/cli/src/workouter_cli/presentation/commands/sessions.py
+++ b/cli/src/workouter_cli/presentation/commands/sessions.py
@@ -1,0 +1,505 @@
+"""Sessions command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine, Mapping
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, TypeVar
+from uuid import UUID
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
+from workouter_cli.domain.exceptions import ValidationError
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+def _require_any_update(payload: Mapping[str, object], message: str) -> None:
+    if not payload:
+        raise ValidationError(message)
+
+
+@click.group(name="sessions")
+def sessions() -> None:
+    """Session lifecycle and set logging commands."""
+
+
+@sessions.command(name="list")
+@click.option("--page", type=int, default=1, show_default=True)
+@click.option("--page-size", type=int, default=20, show_default=True)
+@click.option(
+    "--status",
+    type=click.Choice(["PLANNED", "IN_PROGRESS", "COMPLETED"], case_sensitive=True),
+    default=None,
+)
+@click.option("--mesocycle-id", type=click.UUID, default=None)
+@click.option("--date-from", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--date-to", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.pass_obj
+def list_sessions(
+    ctx: CLIContext,
+    page: int,
+    page_size: int,
+    status: str | None,
+    mesocycle_id: UUID | None,
+    date_from: datetime | None,
+    date_to: datetime | None,
+) -> None:
+    """List sessions."""
+
+    items: list[Session]
+    pagination: dict[str, int]
+    items, pagination = _run(
+        ctx.session_service.list(
+            page=page,
+            page_size=page_size,
+            status=status,
+            mesocycle_id=str(mesocycle_id) if mesocycle_id is not None else None,
+            date_from=date_from.date().isoformat() if date_from is not None else None,
+            date_to=date_to.date().isoformat() if date_to is not None else None,
+        )
+    )
+    payload = {
+        "items": [asdict(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="sessions list")
+
+
+@sessions.command(name="get")
+@click.argument("session_id", type=click.UUID)
+@click.pass_obj
+def get_session(ctx: CLIContext, session_id: UUID) -> None:
+    """Get one session by ID."""
+
+    session: Session = _run(ctx.session_service.get(str(session_id)))
+    _render(ctx, asdict(session), command="sessions get")
+
+
+@sessions.command(name="create")
+@click.option("--planned-session-id", type=click.UUID, default=None)
+@click.option("--mesocycle-id", type=click.UUID, default=None)
+@click.option("--routine-id", type=click.UUID, default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without creating")
+@click.pass_obj
+def create_session(
+    ctx: CLIContext,
+    planned_session_id: UUID | None,
+    mesocycle_id: UUID | None,
+    routine_id: UUID | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Create session."""
+
+    payload: dict[str, str | None] = {
+        "plannedSessionId": str(planned_session_id) if planned_session_id is not None else None,
+        "mesocycleId": str(mesocycle_id) if mesocycle_id is not None else None,
+        "routineId": str(routine_id) if routine_id is not None else None,
+        "notes": notes,
+    }
+    if dry_run:
+        _render(
+            ctx,
+            {"dry_run": True, "operation": "createSession", "input": payload},
+            command="sessions create",
+        )
+        return
+
+    session: Session = _run(ctx.session_service.create(payload))
+    _render(ctx, asdict(session), command="sessions create")
+
+
+@sessions.command(name="start")
+@click.argument("session_id", type=click.UUID)
+@click.pass_obj
+def start_session(ctx: CLIContext, session_id: UUID) -> None:
+    """Start session."""
+
+    session: Session = _run(ctx.session_service.start(str(session_id)))
+    _render(ctx, asdict(session), command="sessions start")
+
+
+@sessions.command(name="complete")
+@click.argument("session_id", type=click.UUID)
+@click.pass_obj
+def complete_session(ctx: CLIContext, session_id: UUID) -> None:
+    """Complete session."""
+
+    session: Session = _run(ctx.session_service.complete(str(session_id)))
+    _render(ctx, asdict(session), command="sessions complete")
+
+
+@sessions.command(name="update")
+@click.argument("session_id", type=click.UUID)
+@click.option("--started-at", type=click.DateTime(), default=None)
+@click.option("--completed-at", type=click.DateTime(), default=None)
+@click.option(
+    "--status",
+    type=click.Choice(["PLANNED", "IN_PROGRESS", "COMPLETED"], case_sensitive=True),
+    default=None,
+)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without updating")
+@click.pass_obj
+def update_session(
+    ctx: CLIContext,
+    session_id: UUID,
+    started_at: datetime | None,
+    completed_at: datetime | None,
+    status: str | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Update session."""
+
+    payload: dict[str, str | None] = {}
+    if started_at is not None:
+        payload["startedAt"] = started_at.isoformat()
+    if completed_at is not None:
+        payload["completedAt"] = completed_at.isoformat()
+    if status is not None:
+        payload["status"] = status
+    if notes is not None:
+        payload["notes"] = notes
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateSession",
+                "id": str(session_id),
+                "input": payload,
+            },
+            command="sessions update",
+        )
+        return
+
+    session: Session = _run(ctx.session_service.update(str(session_id), payload))
+    _render(ctx, asdict(session), command="sessions update")
+
+
+@sessions.command(name="delete")
+@click.argument("session_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def delete_session(ctx: CLIContext, session_id: UUID, force: bool) -> None:
+    """Delete session."""
+
+    if not force:
+        raise ValidationError("Use --force to delete session")
+
+    deleted: bool = _run(ctx.session_service.delete(str(session_id)))
+    _render(ctx, {"id": str(session_id), "deleted": deleted}, command="sessions delete")
+
+
+@sessions.command(name="add-exercise")
+@click.argument("session_id", type=click.UUID)
+@click.option("--exercise-id", type=click.UUID, required=True)
+@click.option("--order", type=int, required=True)
+@click.option("--superset-group", type=int, default=None)
+@click.option("--rest-seconds", type=int, default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_session_exercise(
+    ctx: CLIContext,
+    session_id: UUID,
+    exercise_id: UUID,
+    order: int,
+    superset_group: int | None,
+    rest_seconds: int | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Add exercise to a session."""
+
+    payload: dict[str, object] = {
+        "exerciseId": str(exercise_id),
+        "order": order,
+    }
+    if superset_group is not None:
+        payload["supersetGroup"] = superset_group
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+    if notes is not None:
+        payload["notes"] = notes
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addSessionExercise",
+                "session_id": str(session_id),
+                "input": payload,
+            },
+            command="sessions add-exercise",
+        )
+        return
+
+    session: Session = _run(ctx.session_service.add_exercise(str(session_id), payload))
+    _render(ctx, asdict(session), command="sessions add-exercise")
+
+
+@sessions.command(name="update-exercise")
+@click.argument("session_exercise_id", type=click.UUID)
+@click.option("--order", type=int, default=None)
+@click.option("--superset-group", type=int, default=None)
+@click.option("--rest-seconds", type=int, default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_session_exercise(
+    ctx: CLIContext,
+    session_exercise_id: UUID,
+    order: int | None,
+    superset_group: int | None,
+    rest_seconds: int | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Update one session exercise."""
+
+    payload: dict[str, object] = {}
+    if order is not None:
+        payload["order"] = order
+    if superset_group is not None:
+        payload["supersetGroup"] = superset_group
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+    if notes is not None:
+        payload["notes"] = notes
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateSessionExercise",
+                "id": str(session_exercise_id),
+                "input": payload,
+            },
+            command="sessions update-exercise",
+        )
+        return
+
+    session_exercise: SessionExercise = _run(
+        ctx.session_service.update_exercise(str(session_exercise_id), payload)
+    )
+    _render(ctx, asdict(session_exercise), command="sessions update-exercise")
+
+
+@sessions.command(name="remove-exercise")
+@click.argument("session_exercise_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_session_exercise(ctx: CLIContext, session_exercise_id: UUID, force: bool) -> None:
+    """Remove one exercise from a session."""
+
+    if not force:
+        raise ValidationError("Use --force to remove session exercise")
+
+    deleted: bool = _run(ctx.session_service.remove_exercise(str(session_exercise_id)))
+    _render(
+        ctx,
+        {"id": str(session_exercise_id), "deleted": deleted},
+        command="sessions remove-exercise",
+    )
+
+
+@sessions.command(name="add-set")
+@click.argument("session_exercise_id", type=click.UUID)
+@click.option("--set-number", type=int, required=True)
+@click.option(
+    "--set-type",
+    type=click.Choice(["STANDARD", "DROPSET"], case_sensitive=True),
+    required=True,
+)
+@click.option("--target-reps", type=int, default=None)
+@click.option("--target-rir", type=int, default=None)
+@click.option("--target-weight", type=float, default=None)
+@click.option("--weight-reduction-pct", type=float, default=None)
+@click.option("--rest-seconds", type=int, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_session_set(
+    ctx: CLIContext,
+    session_exercise_id: UUID,
+    set_number: int,
+    set_type: str,
+    target_reps: int | None,
+    target_rir: int | None,
+    target_weight: float | None,
+    weight_reduction_pct: float | None,
+    rest_seconds: int | None,
+    dry_run: bool,
+) -> None:
+    """Add set to a session exercise."""
+
+    payload: dict[str, object] = {
+        "setNumber": set_number,
+        "setType": set_type,
+    }
+    if target_reps is not None:
+        payload["targetReps"] = target_reps
+    if target_rir is not None:
+        payload["targetRir"] = target_rir
+    if target_weight is not None:
+        payload["targetWeightKg"] = target_weight
+    if weight_reduction_pct is not None:
+        payload["weightReductionPct"] = weight_reduction_pct
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addSessionSet",
+                "session_exercise_id": str(session_exercise_id),
+                "input": payload,
+            },
+            command="sessions add-set",
+        )
+        return
+
+    session_exercise: SessionExercise = _run(
+        ctx.session_service.add_set(str(session_exercise_id), payload)
+    )
+    _render(ctx, asdict(session_exercise), command="sessions add-set")
+
+
+@sessions.command(name="update-set")
+@click.argument("set_id", type=click.UUID)
+@click.option("--set-number", type=int, default=None)
+@click.option(
+    "--set-type",
+    type=click.Choice(["STANDARD", "DROPSET"], case_sensitive=True),
+    default=None,
+)
+@click.option("--target-reps", type=int, default=None)
+@click.option("--target-rir", type=int, default=None)
+@click.option("--target-weight", type=float, default=None)
+@click.option("--weight-reduction-pct", type=float, default=None)
+@click.option("--rest-seconds", type=int, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_session_set(
+    ctx: CLIContext,
+    set_id: UUID,
+    set_number: int | None,
+    set_type: str | None,
+    target_reps: int | None,
+    target_rir: int | None,
+    target_weight: float | None,
+    weight_reduction_pct: float | None,
+    rest_seconds: int | None,
+    dry_run: bool,
+) -> None:
+    """Update one session set."""
+
+    payload: dict[str, object] = {}
+    if set_number is not None:
+        payload["setNumber"] = set_number
+    if set_type is not None:
+        payload["setType"] = set_type
+    if target_reps is not None:
+        payload["targetReps"] = target_reps
+    if target_rir is not None:
+        payload["targetRir"] = target_rir
+    if target_weight is not None:
+        payload["targetWeightKg"] = target_weight
+    if weight_reduction_pct is not None:
+        payload["weightReductionPct"] = weight_reduction_pct
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateSessionSet",
+                "id": str(set_id),
+                "input": payload,
+            },
+            command="sessions update-set",
+        )
+        return
+
+    session_set: SessionSet = _run(ctx.session_service.update_set(str(set_id), payload))
+    _render(ctx, asdict(session_set), command="sessions update-set")
+
+
+@sessions.command(name="remove-set")
+@click.argument("set_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_session_set(ctx: CLIContext, set_id: UUID, force: bool) -> None:
+    """Remove one set from a session exercise."""
+
+    if not force:
+        raise ValidationError("Use --force to remove session set")
+
+    deleted: bool = _run(ctx.session_service.remove_set(str(set_id)))
+    _render(ctx, {"id": str(set_id), "deleted": deleted}, command="sessions remove-set")
+
+
+@sessions.command(name="log-set")
+@click.argument("set_id", type=click.UUID)
+@click.option("--reps", type=int, required=True)
+@click.option("--weight", type=float, required=True)
+@click.option("--rir", type=int, default=None)
+@click.option("--performed-at", type=click.DateTime(), default=None)
+@click.pass_obj
+def log_set(
+    ctx: CLIContext,
+    set_id: UUID,
+    reps: int,
+    weight: float,
+    rir: int | None,
+    performed_at: datetime | None,
+) -> None:
+    """Log one set result."""
+
+    payload: dict[str, int | float | str | None] = {
+        "actualReps": reps,
+        "actualWeightKg": weight,
+        "actualRir": rir,
+        "performedAt": performed_at.isoformat() if performed_at is not None else None,
+    }
+    session_set: SessionSet = _run(ctx.session_service.log_set(str(set_id), payload))
+    _render(ctx, asdict(session_set), command="sessions log-set")

--- a/cli/tests/integration/test_session_commands.py
+++ b/cli/tests/integration/test_session_commands.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _session_payload(status: str = "PLANNED") -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "plannedSessionId": None,
+        "mesocycleId": "22222222-2222-2222-2222-222222222222",
+        "routineId": "33333333-3333-3333-3333-333333333333",
+        "status": status,
+        "startedAt": "2026-01-01T10:00:00Z",
+        "completedAt": None,
+        "notes": "Session notes",
+        "exercises": [],
+    }
+
+
+def _session_exercise_payload() -> dict[str, object]:
+    return {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "exercise": {
+            "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "name": "Bench Press",
+        },
+        "order": 1,
+        "supersetGroup": None,
+        "restSeconds": 120,
+        "notes": None,
+        "sets": [],
+    }
+
+
+def _session_set_payload() -> dict[str, object]:
+    return {
+        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "setNumber": 1,
+        "setType": "STANDARD",
+        "targetReps": 10,
+        "targetRir": 2,
+        "targetWeightKg": 80.0,
+        "actualReps": 10,
+        "actualRir": 1,
+        "actualWeightKg": 82.5,
+        "weightReductionPct": None,
+        "restSeconds": 120,
+        "performedAt": "2026-01-01T10:15:00Z",
+    }
+
+
+def test_sessions_list_get_and_lifecycle_commands(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query ListSessions" in query:
+            calls.append("list")
+            return {
+                "sessions": {
+                    "items": [_session_payload("IN_PROGRESS")],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 20,
+                    "totalPages": 1,
+                }
+            }
+        if "query GetSession" in query:
+            calls.append("get")
+            return {"session": _session_payload("IN_PROGRESS")}
+        if "mutation StartSession" in query:
+            calls.append("start")
+            return {"startSession": _session_payload("IN_PROGRESS")}
+        if "mutation CompleteSession" in query:
+            calls.append("complete")
+            return {"completeSession": _session_payload("COMPLETED")}
+        if "mutation DeleteSession" in query:
+            calls.append("delete")
+            return {"deleteSession": True}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    list_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "list",
+            "--status",
+            "IN_PROGRESS",
+            "--mesocycle-id",
+            "22222222-2222-2222-2222-222222222222",
+            "--date-from",
+            "2026-01-01",
+            "--date-to",
+            "2026-01-31",
+        ],
+    )
+    assert list_result.exit_code == 0
+    assert json.loads(list_result.output.strip())["success"] is True
+
+    get_result = runner.invoke(
+        cli,
+        ["--json", "sessions", "get", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert get_result.exit_code == 0
+
+    start_result = runner.invoke(
+        cli,
+        ["--json", "sessions", "start", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert start_result.exit_code == 0
+
+    complete_result = runner.invoke(
+        cli,
+        ["--json", "sessions", "complete", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert complete_result.exit_code == 0
+
+    delete_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "delete",
+            "11111111-1111-1111-1111-111111111111",
+            "--force",
+        ],
+    )
+    assert delete_result.exit_code == 0
+    assert json.loads(delete_result.output.strip())["data"]["deleted"] is True
+    assert calls == ["list", "get", "start", "complete", "delete"]
+
+
+def test_sessions_create_update_and_dry_run_validation(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock(return_value={"createSession": _session_payload("PLANNED")})
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    dry_run_create = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "create",
+            "--routine-id",
+            "33333333-3333-3333-3333-333333333333",
+            "--dry-run",
+        ],
+    )
+    assert dry_run_create.exit_code == 0
+    assert json.loads(dry_run_create.output.strip())["data"]["dry_run"] is True
+    mock_execute.assert_not_called()
+
+    create_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "create",
+            "--routine-id",
+            "33333333-3333-3333-3333-333333333333",
+        ],
+    )
+    assert create_result.exit_code == 0
+    assert json.loads(create_result.output.strip())["data"]["status"] == "PLANNED"
+
+    update_validation = runner.invoke(
+        cli,
+        ["--json", "sessions", "update", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert update_validation.exit_code == 1
+    payload = json.loads(update_validation.output.strip())
+    assert payload["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_sessions_nested_commands_and_remove_validations(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "mutation AddSessionExercise" in query:
+            calls.append("add-exercise")
+            return {"addSessionExercise": _session_payload("IN_PROGRESS")}
+        if "mutation UpdateSessionExercise" in query:
+            calls.append("update-exercise")
+            return {"updateSessionExercise": _session_exercise_payload()}
+        if "mutation RemoveSessionExercise" in query:
+            calls.append("remove-exercise")
+            return {"removeSessionExercise": True}
+        if "mutation AddSessionSet" in query:
+            calls.append("add-set")
+            payload = _session_exercise_payload()
+            payload["sets"] = [_session_set_payload()]
+            return {"addSessionSet": payload}
+        if "mutation UpdateSessionSet" in query:
+            calls.append("update-set")
+            return {"updateSessionSet": _session_set_payload()}
+        if "mutation RemoveSessionSet" in query:
+            calls.append("remove-set")
+            return {"removeSessionSet": True}
+        if "mutation LogSetResult" in query:
+            calls.append("log-set")
+            return {"logSetResult": _session_set_payload()}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    add_exercise_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "add-exercise",
+            "11111111-1111-1111-1111-111111111111",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--order",
+            "1",
+            "--dry-run",
+        ],
+    )
+    assert add_exercise_dry_run.exit_code == 0
+    assert json.loads(add_exercise_dry_run.output.strip())["data"]["dry_run"] is True
+
+    add_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "add-exercise",
+            "11111111-1111-1111-1111-111111111111",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--order",
+            "1",
+        ],
+    )
+    assert add_exercise.exit_code == 0
+
+    update_exercise_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "update-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ],
+    )
+    assert update_exercise_validation.exit_code == 1
+
+    update_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "update-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--order",
+            "2",
+        ],
+    )
+    assert update_exercise.exit_code == 0
+
+    remove_exercise_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "remove-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ],
+    )
+    assert remove_exercise_validation.exit_code == 1
+
+    remove_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "remove-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--force",
+        ],
+    )
+    assert remove_exercise.exit_code == 0
+
+    add_set_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "add-set",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--set-number",
+            "1",
+            "--set-type",
+            "STANDARD",
+            "--dry-run",
+        ],
+    )
+    assert add_set_dry_run.exit_code == 0
+
+    add_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "add-set",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--set-number",
+            "1",
+            "--set-type",
+            "STANDARD",
+        ],
+    )
+    assert add_set.exit_code == 0
+
+    update_set_validation = runner.invoke(
+        cli,
+        ["--json", "sessions", "update-set", "cccccccc-cccc-cccc-cccc-cccccccccccc"],
+    )
+    assert update_set_validation.exit_code == 1
+
+    update_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "update-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--target-reps",
+            "12",
+        ],
+    )
+    assert update_set.exit_code == 0
+
+    remove_set_validation = runner.invoke(
+        cli,
+        ["--json", "sessions", "remove-set", "cccccccc-cccc-cccc-cccc-cccccccccccc"],
+    )
+    assert remove_set_validation.exit_code == 1
+
+    remove_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "remove-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--force",
+        ],
+    )
+    assert remove_set.exit_code == 0
+
+    log_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "sessions",
+            "log-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--reps",
+            "10",
+            "--weight",
+            "82.5",
+            "--rir",
+            "1",
+        ],
+    )
+    assert log_set.exit_code == 0
+    assert json.loads(log_set.output.strip())["data"]["actual_reps"] == 10
+    assert calls == [
+        "add-exercise",
+        "update-exercise",
+        "remove-exercise",
+        "add-set",
+        "update-set",
+        "remove-set",
+        "log-set",
+    ]

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -86,3 +86,25 @@ def test_schema_unknown_command_fails() -> None:
 
     assert result.exit_code != 0
     assert "Unknown command" in result.output
+
+
+def test_help_includes_sessions_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "sessions" in result.output
+
+
+def test_schema_sessions_list_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "sessions list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "sessions list"
+    assert payload["description"] == "List sessions."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--status" in option_names
+    assert "--mesocycle-id" in option_names

--- a/cli/tests/unit/test_session_repository.py
+++ b/cli/tests/unit/test_session_repository.py
@@ -4,6 +4,16 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from workouter_cli.infrastructure.graphql.mutations.session import (
+    ADD_SESSION_EXERCISE,
+    ADD_SESSION_SET,
+    DELETE_SESSION,
+    REMOVE_SESSION_EXERCISE,
+    REMOVE_SESSION_SET,
+    UPDATE_SESSION_EXERCISE,
+    UPDATE_SESSION_SET,
+)
+from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 
 
@@ -89,4 +99,218 @@ async def test_repository_list_maps_sessions_and_pagination() -> None:
     assert items[0].status == "IN_PROGRESS"
     assert pagination["total"] == 1
     assert pagination["pageSize"] == 2
-    client.execute.assert_awaited_once()
+    client.execute.assert_awaited_once_with(
+        LIST_SESSIONS,
+        {
+            "pagination": {"page": 1, "pageSize": 2},
+            "status": "IN_PROGRESS",
+            "mesocycleId": None,
+            "dateFrom": None,
+            "dateTo": None,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_get_maps_session() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"session": _session_payload("IN_PROGRESS")})
+
+    repository = GraphQLSessionRepository(client=client)
+    session = await repository.get("11111111-1111-1111-1111-111111111111")
+
+    assert session.id == "11111111-1111-1111-1111-111111111111"
+    client.execute.assert_awaited_once_with(
+        GET_SESSION, {"id": "11111111-1111-1111-1111-111111111111"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_delete_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"deleteSession": True})
+
+    repository = GraphQLSessionRepository(client=client)
+    deleted = await repository.delete("11111111-1111-1111-1111-111111111111")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        DELETE_SESSION,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_add_exercise_maps_session() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"addSessionExercise": _session_payload("IN_PROGRESS")})
+
+    repository = GraphQLSessionRepository(client=client)
+    session = await repository.add_exercise(
+        "11111111-1111-1111-1111-111111111111",
+        {
+            "exerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "order": 1,
+        },
+    )
+
+    assert session.status == "IN_PROGRESS"
+    client.execute.assert_awaited_once_with(
+        ADD_SESSION_EXERCISE,
+        {
+            "sessionId": "11111111-1111-1111-1111-111111111111",
+            "input": {
+                "exerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "order": 1,
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_exercise_maps_session_exercise() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "updateSessionExercise": {
+                "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "exercise": {
+                    "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "name": "Bench Press",
+                },
+                "order": 2,
+                "supersetGroup": None,
+                "restSeconds": 120,
+                "notes": "Heavy",
+                "sets": [],
+            }
+        }
+    )
+
+    repository = GraphQLSessionRepository(client=client)
+    session_exercise = await repository.update_exercise(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2}
+    )
+
+    assert session_exercise.order == 2
+    assert session_exercise.exercise_name == "Bench Press"
+    client.execute.assert_awaited_once_with(
+        UPDATE_SESSION_EXERCISE,
+        {"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "input": {"order": 2}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_exercise_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removeSessionExercise": True})
+
+    repository = GraphQLSessionRepository(client=client)
+    deleted = await repository.remove_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_SESSION_EXERCISE,
+        {"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_add_set_maps_session_exercise() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "addSessionSet": {
+                "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "exercise": {
+                    "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "name": "Bench Press",
+                },
+                "order": 1,
+                "supersetGroup": None,
+                "restSeconds": 120,
+                "notes": None,
+                "sets": [
+                    {
+                        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "setNumber": 1,
+                        "setType": "STANDARD",
+                        "targetReps": 10,
+                        "targetRir": 2,
+                        "targetWeightKg": 80.0,
+                        "actualReps": None,
+                        "actualRir": None,
+                        "actualWeightKg": None,
+                        "weightReductionPct": None,
+                        "restSeconds": 120,
+                        "performedAt": None,
+                    }
+                ],
+            }
+        }
+    )
+
+    repository = GraphQLSessionRepository(client=client)
+    session_exercise = await repository.add_set(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        {"setNumber": 1, "setType": "STANDARD"},
+    )
+
+    assert len(session_exercise.sets) == 1
+    assert session_exercise.sets[0].set_type == "STANDARD"
+    client.execute.assert_awaited_once_with(
+        ADD_SESSION_SET,
+        {
+            "sessionExerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "input": {"setNumber": 1, "setType": "STANDARD"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_set_maps_session_set() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "updateSessionSet": {
+                "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "setNumber": 1,
+                "setType": "STANDARD",
+                "targetReps": 12,
+                "targetRir": 1,
+                "targetWeightKg": 82.5,
+                "actualReps": None,
+                "actualRir": None,
+                "actualWeightKg": None,
+                "weightReductionPct": None,
+                "restSeconds": 120,
+                "performedAt": None,
+            }
+        }
+    )
+
+    repository = GraphQLSessionRepository(client=client)
+    session_set = await repository.update_set(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetReps": 12}
+    )
+
+    assert session_set.target_reps == 12
+    client.execute.assert_awaited_once_with(
+        UPDATE_SESSION_SET,
+        {"id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "input": {"targetReps": 12}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_set_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removeSessionSet": True})
+
+    repository = GraphQLSessionRepository(client=client)
+    deleted = await repository.remove_set("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_SESSION_SET,
+        {"id": "cccccccc-cccc-cccc-cccc-cccccccccccc"},
+    )

--- a/cli/tests/unit/test_session_service.py
+++ b/cli/tests/unit/test_session_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from workouter_cli.application.services.session_service import SessionService
-from workouter_cli.domain.entities.session import Session
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
 
 def _session(status: str) -> Session:
@@ -19,6 +19,36 @@ def _session(status: str) -> Session:
         completed_at=None,
         notes=None,
         exercises=(),
+    )
+
+
+def _session_exercise() -> SessionExercise:
+    return SessionExercise(
+        id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        exercise_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        exercise_name="Bench Press",
+        order=1,
+        superset_group=None,
+        rest_seconds=120,
+        notes=None,
+        sets=(),
+    )
+
+
+def _session_set() -> SessionSet:
+    return SessionSet(
+        id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+        set_number=1,
+        set_type="STANDARD",
+        target_reps=10,
+        target_rir=2,
+        target_weight_kg=80.0,
+        actual_reps=None,
+        actual_rir=None,
+        actual_weight_kg=None,
+        weight_reduction_pct=None,
+        rest_seconds=120,
+        performed_at=None,
     )
 
 
@@ -68,8 +98,91 @@ async def test_session_service_list_delegates_to_repository(mocker) -> None:  # 
     repository.list = AsyncMock(return_value=([_session("IN_PROGRESS")], {"total": 1}))
     service = SessionService(session_repository=repository)
 
-    items, pagination = await service.list(page=1, page_size=2, status="IN_PROGRESS")
+    items, pagination = await service.list(
+        page=1,
+        page_size=2,
+        status="IN_PROGRESS",
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+    )
 
     assert len(items) == 1
     assert pagination["total"] == 1
-    repository.list.assert_awaited_once_with(page=1, page_size=2, status="IN_PROGRESS")
+    repository.list.assert_awaited_once_with(
+        page=1,
+        page_size=2,
+        status="IN_PROGRESS",
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        date_from="2026-01-01",
+        date_to="2026-01-31",
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_service_add_and_update_nested_entities(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.add_exercise = AsyncMock(return_value=_session("IN_PROGRESS"))
+    repository.update_exercise = AsyncMock(return_value=_session_exercise())
+    repository.add_set = AsyncMock(return_value=_session_exercise())
+    repository.update_set = AsyncMock(return_value=_session_set())
+    repository.log_set = AsyncMock(return_value=_session_set())
+    service = SessionService(session_repository=repository)
+
+    await service.add_exercise("11111111-1111-1111-1111-111111111111", {"order": 1})
+    await service.update_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2})
+    await service.add_set("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"setNumber": 1})
+    await service.update_set("cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetReps": 12})
+    await service.log_set(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        {"actualReps": 10, "actualWeightKg": 82.5},
+    )
+
+    repository.add_exercise.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111", {"order": 1}
+    )
+    repository.update_exercise.assert_awaited_once_with(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2}
+    )
+    repository.add_set.assert_awaited_once_with(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"setNumber": 1}
+    )
+    repository.update_set.assert_awaited_once_with(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetReps": 12}
+    )
+    repository.log_set.assert_awaited_once_with(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        {"actualReps": 10, "actualWeightKg": 82.5},
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_service_get_and_delete_delegate(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.get = AsyncMock(return_value=_session("PLANNED"))
+    repository.delete = AsyncMock(return_value=True)
+    service = SessionService(session_repository=repository)
+
+    fetched = await service.get("11111111-1111-1111-1111-111111111111")
+    deleted = await service.delete("11111111-1111-1111-1111-111111111111")
+
+    assert fetched.status == "PLANNED"
+    assert deleted is True
+    repository.get.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+    repository.delete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_session_service_remove_nested_entities_delegate(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.remove_exercise = AsyncMock(return_value=True)
+    repository.remove_set = AsyncMock(return_value=True)
+    service = SessionService(session_repository=repository)
+
+    removed_exercise = await service.remove_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    removed_set = await service.remove_set("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+    assert removed_exercise is True
+    assert removed_set is True
+    repository.remove_exercise.assert_awaited_once_with("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    repository.remove_set.assert_awaited_once_with("cccccccc-cccc-cccc-cccc-cccccccccccc")


### PR DESCRIPTION
## Summary
- add a new `sessions` command group with parity subcommands: `list`, `get`, `create`, `start`, `complete`, `update`, `delete`, `add-exercise`, `update-exercise`, `remove-exercise`, `add-set`, `update-set`, `remove-set`, and `log-set`
- extend session GraphQL queries/mutations, repository protocol/implementation, and service methods to support full session lifecycle and nested exercise/set operations
- add integration and unit test coverage for sessions commands, service delegation, repository mappings, and CLI schema/help visibility

## Validation
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest`

Closes #21