### PR TITLE
[CLI][Routines] Implement routine composition commands

### DIFF
--- a/cli/src/workouter_cli/application/services/__init__.py
+++ b/cli/src/workouter_cli/application/services/__init__.py
@@ -3,6 +3,13 @@
 from workouter_cli.application.services.exercise_service import ExerciseService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.calendar_service import CalendarService
+from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.workflow_service import WorkflowService
 
-__all__ = ["ExerciseService", "SessionService", "CalendarService", "WorkflowService"]
+__all__ = [
+    "ExerciseService",
+    "SessionService",
+    "CalendarService",
+    "RoutineService",
+    "WorkflowService",
+]

--- a/cli/src/workouter_cli/application/services/routine_service.py
+++ b/cli/src/workouter_cli/application/services/routine_service.py
@@ -1,0 +1,35 @@
+"""Routine application service."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+from workouter_cli.domain.repositories.routine import RoutineRepository
+
+
+class RoutineService:
+    """Routine composition use-cases orchestration."""
+
+    def __init__(self, routine_repository: RoutineRepository) -> None:
+        self.routine_repository = routine_repository
+
+    async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
+        return await self.routine_repository.add_exercise(routine_id, payload)
+
+    async def update_exercise(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        return await self.routine_repository.update_exercise(routine_exercise_id, payload)
+
+    async def remove_exercise(self, routine_exercise_id: str) -> bool:
+        return await self.routine_repository.remove_exercise(routine_exercise_id)
+
+    async def add_set(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        return await self.routine_repository.add_set(routine_exercise_id, payload)
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> RoutineSet:
+        return await self.routine_repository.update_set(set_id, payload)
+
+    async def remove_set(self, set_id: str) -> bool:
+        return await self.routine_repository.remove_set(set_id)

--- a/cli/src/workouter_cli/domain/entities/__init__.py
+++ b/cli/src/workouter_cli/domain/entities/__init__.py
@@ -1,16 +1,20 @@
 """Domain entities package."""
 
-from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
-from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
+from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
 __all__ = [
-    "Exercise",
-    "ExerciseMuscleGroup",
     "MuscleGroup",
-    "Session",
-    "SessionExercise",
+    "ExerciseMuscleGroup",
+    "Exercise",
+    "RoutineSet",
+    "RoutineExercise",
+    "Routine",
     "SessionSet",
-    "CalendarDay",
+    "SessionExercise",
+    "Session",
     "PlannedSession",
+    "CalendarDay",
 ]

--- a/cli/src/workouter_cli/domain/entities/routine.py
+++ b/cli/src/workouter_cli/domain/entities/routine.py
@@ -1,0 +1,44 @@
+"""Routine domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class RoutineSet:
+    """Routine set prescription details."""
+
+    id: str
+    set_number: int
+    set_type: str
+    target_reps_min: int | None
+    target_reps_max: int | None
+    target_rir: int | None
+    target_weight_kg: float | None
+    weight_reduction_pct: float | None
+    rest_seconds: int | None
+
+
+@dataclass(slots=True, frozen=True)
+class RoutineExercise:
+    """Exercise entry inside a routine."""
+
+    id: str
+    exercise_id: str
+    exercise_name: str
+    order: int
+    superset_group: int | None
+    rest_seconds: int | None
+    notes: str | None
+    sets: tuple[RoutineSet, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class Routine:
+    """Routine aggregate root."""
+
+    id: str
+    name: str
+    description: str | None
+    exercises: tuple[RoutineExercise, ...]

--- a/cli/src/workouter_cli/domain/repositories/__init__.py
+++ b/cli/src/workouter_cli/domain/repositories/__init__.py
@@ -3,5 +3,11 @@
 from workouter_cli.domain.repositories.exercise import ExerciseRepository
 from workouter_cli.domain.repositories.session import SessionRepository
 from workouter_cli.domain.repositories.calendar import CalendarRepository
+from workouter_cli.domain.repositories.routine import RoutineRepository
 
-__all__ = ["ExerciseRepository", "SessionRepository", "CalendarRepository"]
+__all__ = [
+    "ExerciseRepository",
+    "SessionRepository",
+    "CalendarRepository",
+    "RoutineRepository",
+]

--- a/cli/src/workouter_cli/domain/repositories/routine.py
+++ b/cli/src/workouter_cli/domain/repositories/routine.py
@@ -1,0 +1,39 @@
+"""Routine repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+
+
+class RoutineRepository(Protocol):
+    """Persistence contract for routines."""
+
+    async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
+        """Add one exercise to a routine."""
+        ...
+
+    async def update_exercise(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        """Update one routine exercise and return its latest state."""
+        ...
+
+    async def remove_exercise(self, routine_exercise_id: str) -> bool:
+        """Remove one exercise from a routine."""
+        ...
+
+    async def add_set(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        """Add one set to a routine exercise and return latest state."""
+        ...
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> RoutineSet:
+        """Update one routine set."""
+        ...
+
+    async def remove_set(self, set_id: str) -> bool:
+        """Remove one set from a routine exercise."""
+        ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
 
@@ -93,6 +94,61 @@ def map_session(data: dict[str, Any]) -> Session:
         completed_at=(str(data["completedAt"]) if data.get("completedAt") is not None else None),
         notes=str(data["notes"]) if data.get("notes") is not None else None,
         exercises=tuple(map_session_exercise(item) for item in data.get("exercises", [])),
+    )
+
+
+def map_routine_set(data: dict[str, Any]) -> RoutineSet:
+    """Map GraphQL routine set payload to domain entity."""
+
+    return RoutineSet(
+        id=str(data["id"]),
+        set_number=int(data["setNumber"]),
+        set_type=str(data["setType"]),
+        target_reps_min=(
+            int(data["targetRepsMin"]) if data.get("targetRepsMin") is not None else None
+        ),
+        target_reps_max=(
+            int(data["targetRepsMax"]) if data.get("targetRepsMax") is not None else None
+        ),
+        target_rir=int(data["targetRir"]) if data.get("targetRir") is not None else None,
+        target_weight_kg=(
+            float(data["targetWeightKg"]) if data.get("targetWeightKg") is not None else None
+        ),
+        weight_reduction_pct=(
+            float(data["weightReductionPct"])
+            if data.get("weightReductionPct") is not None
+            else None
+        ),
+        rest_seconds=int(data["restSeconds"]) if data.get("restSeconds") is not None else None,
+    )
+
+
+def map_routine_exercise(data: dict[str, Any]) -> RoutineExercise:
+    """Map GraphQL routine exercise payload to domain entity."""
+
+    exercise = data["exercise"]
+    return RoutineExercise(
+        id=str(data["id"]),
+        exercise_id=str(exercise["id"]),
+        exercise_name=str(exercise["name"]),
+        order=int(data["order"]),
+        superset_group=(
+            int(data["supersetGroup"]) if data.get("supersetGroup") is not None else None
+        ),
+        rest_seconds=int(data["restSeconds"]) if data.get("restSeconds") is not None else None,
+        notes=str(data["notes"]) if data.get("notes") is not None else None,
+        sets=tuple(map_routine_set(item) for item in data.get("sets", [])),
+    )
+
+
+def map_routine(data: dict[str, Any]) -> Routine:
+    """Map GraphQL routine payload to domain entity."""
+
+    return Routine(
+        id=str(data["id"]),
+        name=str(data["name"]),
+        description=str(data["description"]) if data.get("description") is not None else None,
+        exercises=tuple(map_routine_exercise(item) for item in data.get("exercises", [])),
     )
 
 

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -5,6 +5,14 @@ from workouter_cli.infrastructure.graphql.mutations.exercise import (
     DELETE_EXERCISE,
     UPDATE_EXERCISE,
 )
+from workouter_cli.infrastructure.graphql.mutations.routine import (
+    ADD_ROUTINE_EXERCISE,
+    ADD_ROUTINE_SET,
+    REMOVE_ROUTINE_EXERCISE,
+    REMOVE_ROUTINE_SET,
+    UPDATE_ROUTINE_EXERCISE,
+    UPDATE_ROUTINE_SET,
+)
 from workouter_cli.infrastructure.graphql.mutations.session import (
     ADD_SESSION_EXERCISE,
     ADD_SESSION_SET,
@@ -24,6 +32,12 @@ __all__ = [
     "CREATE_EXERCISE",
     "UPDATE_EXERCISE",
     "DELETE_EXERCISE",
+    "ADD_ROUTINE_EXERCISE",
+    "UPDATE_ROUTINE_EXERCISE",
+    "REMOVE_ROUTINE_EXERCISE",
+    "ADD_ROUTINE_SET",
+    "UPDATE_ROUTINE_SET",
+    "REMOVE_ROUTINE_SET",
     "CREATE_SESSION",
     "START_SESSION",
     "COMPLETE_SESSION",

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/routine.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/routine.py
@@ -1,0 +1,99 @@
+"""Routine GraphQL mutations."""
+
+from workouter_cli.infrastructure.graphql.queries.routine import ROUTINE_FIELDS
+
+ROUTINE_EXERCISE_FIELDS = """
+id
+exercise {
+  id
+  name
+}
+order
+supersetGroup
+restSeconds
+notes
+sets {
+  id
+  setNumber
+  setType
+  targetRepsMin
+  targetRepsMax
+  targetRir
+  targetWeightKg
+  weightReductionPct
+  restSeconds
+}
+"""
+
+ROUTINE_SET_FIELDS = """
+id
+setNumber
+setType
+targetRepsMin
+targetRepsMax
+targetRir
+targetWeightKg
+weightReductionPct
+restSeconds
+"""
+
+ADD_ROUTINE_EXERCISE = (
+    """
+mutation AddRoutineExercise($routineId: UUID!, $input: AddRoutineExerciseInput!) {
+  addRoutineExercise(routineId: $routineId, input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_FIELDS
+)
+
+
+UPDATE_ROUTINE_EXERCISE = (
+    """
+mutation UpdateRoutineExercise($id: UUID!, $input: UpdateRoutineExerciseInput!) {
+  updateRoutineExercise(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_EXERCISE_FIELDS
+)
+
+
+REMOVE_ROUTINE_EXERCISE = """
+mutation RemoveRoutineExercise($id: UUID!) {
+  removeRoutineExercise(id: $id)
+}
+"""
+
+
+ADD_ROUTINE_SET = (
+    """
+mutation AddRoutineSet($routineExerciseId: UUID!, $input: AddRoutineSetInput!) {
+  addRoutineSet(routineExerciseId: $routineExerciseId, input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_EXERCISE_FIELDS
+)
+
+
+UPDATE_ROUTINE_SET = (
+    """
+mutation UpdateRoutineSet($id: UUID!, $input: UpdateRoutineSetInput!) {
+  updateRoutineSet(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_SET_FIELDS
+)
+
+
+REMOVE_ROUTINE_SET = """
+mutation RemoveRoutineSet($id: UUID!) {
+  removeRoutineSet(id: $id)
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -2,6 +2,14 @@
 
 from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
 from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
+from workouter_cli.infrastructure.graphql.queries.routine import ROUTINE_FIELDS
 from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 
-__all__ = ["GET_EXERCISE", "LIST_EXERCISES", "CALENDAR_DAY", "LIST_SESSIONS", "GET_SESSION"]
+__all__ = [
+    "GET_EXERCISE",
+    "LIST_EXERCISES",
+    "CALENDAR_DAY",
+    "ROUTINE_FIELDS",
+    "LIST_SESSIONS",
+    "GET_SESSION",
+]

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/routine.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/routine.py
@@ -1,0 +1,29 @@
+"""Routine GraphQL queries."""
+
+ROUTINE_FIELDS = """
+id
+name
+description
+exercises {
+  id
+  exercise {
+    id
+    name
+  }
+  order
+  supersetGroup
+  restSeconds
+  notes
+  sets {
+    id
+    setNumber
+    setType
+    targetRepsMin
+    targetRepsMax
+    targetRir
+    targetWeightKg
+    weightReductionPct
+    restSeconds
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/repositories/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/__init__.py
@@ -3,9 +3,11 @@
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
+from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 
 __all__ = [
     "GraphQLExerciseRepository",
     "GraphQLSessionRepository",
     "GraphQLCalendarRepository",
+    "GraphQLRoutineRepository",
 ]

--- a/cli/src/workouter_cli/infrastructure/repositories/routine.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/routine.py
@@ -1,0 +1,67 @@
+"""GraphQL-backed routine repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+from workouter_cli.domain.repositories.routine import RoutineRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import (
+    map_routine,
+    map_routine_exercise,
+    map_routine_set,
+)
+from workouter_cli.infrastructure.graphql.mutations.routine import (
+    ADD_ROUTINE_EXERCISE,
+    ADD_ROUTINE_SET,
+    REMOVE_ROUTINE_EXERCISE,
+    REMOVE_ROUTINE_SET,
+    UPDATE_ROUTINE_EXERCISE,
+    UPDATE_ROUTINE_SET,
+)
+
+
+class GraphQLRoutineRepository(RoutineRepository):
+    """Routine repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
+        result = await self.client.execute(
+            ADD_ROUTINE_EXERCISE,
+            {"routineId": routine_id, "input": payload},
+        )
+        return map_routine(result["addRoutineExercise"])
+
+    async def update_exercise(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        result = await self.client.execute(
+            UPDATE_ROUTINE_EXERCISE,
+            {"id": routine_exercise_id, "input": payload},
+        )
+        return map_routine_exercise(result["updateRoutineExercise"])
+
+    async def remove_exercise(self, routine_exercise_id: str) -> bool:
+        result = await self.client.execute(REMOVE_ROUTINE_EXERCISE, {"id": routine_exercise_id})
+        return bool(result["removeRoutineExercise"])
+
+    async def add_set(
+        self, routine_exercise_id: str, payload: dict[str, object]
+    ) -> RoutineExercise:
+        result = await self.client.execute(
+            ADD_ROUTINE_SET,
+            {"routineExerciseId": routine_exercise_id, "input": payload},
+        )
+        return map_routine_exercise(result["addRoutineSet"])
+
+    async def update_set(self, set_id: str, payload: dict[str, object]) -> RoutineSet:
+        result = await self.client.execute(
+            UPDATE_ROUTINE_SET,
+            {"id": set_id, "input": payload},
+        )
+        return map_routine_set(result["updateRoutineSet"])
+
+    async def remove_set(self, set_id: str) -> bool:
+        result = await self.client.execute(REMOVE_ROUTINE_SET, {"id": set_id})
+        return bool(result["removeRoutineSet"])

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from workouter_cli.application.formatters.factory import get_formatter
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.workflow_service import WorkflowService
 from workouter_cli.domain.exceptions import AuthError, CLIError
@@ -18,8 +19,10 @@ from workouter_cli.infrastructure.config.loader import ConfigError, load_config
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.presentation.commands.exercises import exercises
+from workouter_cli.presentation.commands.routines import routines
 from workouter_cli.presentation.commands.sessions import sessions
 from workouter_cli.presentation.commands.workout import workout
 from workouter_cli.presentation.context import CLIContext
@@ -127,8 +130,9 @@ def _build_schema(command_name: str) -> dict[str, Any]:
                 "required": parameter.required,
                 "description": parameter.help or "",
             }
-            if parameter.default is not None:
-                option_schema["default"] = parameter.default
+            default_value = parameter.default
+            if isinstance(default_value, (str, int, float, bool, list, dict, tuple)):
+                option_schema["default"] = default_value
             options.append(option_schema)
             if parameter.required and flag_name.startswith("--"):
                 required_flags.append(flag_name)
@@ -184,9 +188,11 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
             url=str(config.api_url), api_key=config.api_key, timeout=effective_timeout
         )
         exercise_repository = GraphQLExerciseRepository(client=client)
+        routine_repository = GraphQLRoutineRepository(client=client)
         session_repository = GraphQLSessionRepository(client=client)
         calendar_repository = GraphQLCalendarRepository(client=client)
         exercise_service = ExerciseService(exercise_repository=exercise_repository)
+        routine_service = RoutineService(routine_repository=routine_repository)
         session_service = SessionService(session_repository=session_repository)
         calendar_service = CalendarService(calendar_repository=calendar_repository)
         workflow_service = WorkflowService(
@@ -199,6 +205,7 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
             output_json=output_json,
             timeout=effective_timeout,
             exercise_service=exercise_service,
+            routine_service=routine_service,
             session_service=session_service,
             calendar_service=calendar_service,
             workflow_service=workflow_service,
@@ -244,5 +251,6 @@ def raise_auth() -> None:
 
 
 cli.add_command(exercises)
+cli.add_command(routines)
 cli.add_command(sessions)
 cli.add_command(workout)

--- a/cli/src/workouter_cli/presentation/commands/routines.py
+++ b/cli/src/workouter_cli/presentation/commands/routines.py
@@ -1,0 +1,323 @@
+"""Routines command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine, Mapping
+from dataclasses import asdict
+from typing import Any, TypeVar
+from uuid import UUID
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+from workouter_cli.domain.exceptions import ValidationError
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+def _require_any_update(payload: Mapping[str, object], message: str) -> None:
+    if not payload:
+        raise ValidationError(message)
+
+
+@click.group(name="routines")
+def routines() -> None:
+    """Routine composition commands."""
+
+
+@routines.command(name="add-exercise")
+@click.argument("routine_id", type=click.UUID)
+@click.option("--exercise-id", type=click.UUID, required=True)
+@click.option("--order", type=click.IntRange(min=1), required=True)
+@click.option("--superset-group", type=click.IntRange(min=1), default=None)
+@click.option("--rest-seconds", type=click.IntRange(min=0), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_routine_exercise(
+    ctx: CLIContext,
+    routine_id: UUID,
+    exercise_id: UUID,
+    order: int,
+    superset_group: int | None,
+    rest_seconds: int | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Add exercise to a routine."""
+
+    payload: dict[str, object] = {
+        "exerciseId": str(exercise_id),
+        "order": order,
+    }
+    if superset_group is not None:
+        payload["supersetGroup"] = superset_group
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+    if notes is not None:
+        payload["notes"] = notes
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addRoutineExercise",
+                "routine_id": str(routine_id),
+                "input": payload,
+            },
+            command="routines add-exercise",
+        )
+        return
+
+    routine: Routine = _run(ctx.routine_service.add_exercise(str(routine_id), payload))
+    _render(ctx, asdict(routine), command="routines add-exercise")
+
+
+@routines.command(name="update-exercise")
+@click.argument("routine_exercise_id", type=click.UUID)
+@click.option("--order", type=click.IntRange(min=1), default=None)
+@click.option("--superset-group", type=click.IntRange(min=1), default=None)
+@click.option("--rest-seconds", type=click.IntRange(min=0), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_routine_exercise(
+    ctx: CLIContext,
+    routine_exercise_id: UUID,
+    order: int | None,
+    superset_group: int | None,
+    rest_seconds: int | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Update one routine exercise."""
+
+    payload: dict[str, object] = {}
+    if order is not None:
+        payload["order"] = order
+    if superset_group is not None:
+        payload["supersetGroup"] = superset_group
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+    if notes is not None:
+        payload["notes"] = notes
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateRoutineExercise",
+                "id": str(routine_exercise_id),
+                "input": payload,
+            },
+            command="routines update-exercise",
+        )
+        return
+
+    routine_exercise: RoutineExercise = _run(
+        ctx.routine_service.update_exercise(str(routine_exercise_id), payload)
+    )
+    _render(ctx, asdict(routine_exercise), command="routines update-exercise")
+
+
+@routines.command(name="remove-exercise")
+@click.argument("routine_exercise_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_routine_exercise(ctx: CLIContext, routine_exercise_id: UUID, force: bool) -> None:
+    """Remove one exercise from a routine."""
+
+    if not force:
+        raise ValidationError("Use --force to remove routine exercise")
+
+    deleted: bool = _run(ctx.routine_service.remove_exercise(str(routine_exercise_id)))
+    _render(
+        ctx,
+        {"id": str(routine_exercise_id), "deleted": deleted},
+        command="routines remove-exercise",
+    )
+
+
+@routines.command(name="add-set")
+@click.argument("routine_exercise_id", type=click.UUID)
+@click.option("--set-number", type=click.IntRange(min=1), required=True)
+@click.option(
+    "--set-type",
+    type=click.Choice(["STANDARD", "DROPSET"], case_sensitive=True),
+    required=True,
+)
+@click.option("--target-reps-min", type=click.IntRange(min=1), default=None)
+@click.option("--target-reps-max", type=click.IntRange(min=1), default=None)
+@click.option("--target-rir", type=click.IntRange(min=0), default=None)
+@click.option("--target-weight", type=click.FloatRange(min=0), default=None)
+@click.option("--weight-reduction-pct", type=click.FloatRange(min=0, max=100), default=None)
+@click.option("--rest-seconds", type=click.IntRange(min=0), default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_routine_set(
+    ctx: CLIContext,
+    routine_exercise_id: UUID,
+    set_number: int,
+    set_type: str,
+    target_reps_min: int | None,
+    target_reps_max: int | None,
+    target_rir: int | None,
+    target_weight: float | None,
+    weight_reduction_pct: float | None,
+    rest_seconds: int | None,
+    dry_run: bool,
+) -> None:
+    """Add set to a routine exercise."""
+
+    if (
+        target_reps_min is not None
+        and target_reps_max is not None
+        and target_reps_min > target_reps_max
+    ):
+        raise ValidationError("--target-reps-min cannot be greater than --target-reps-max")
+
+    payload: dict[str, object] = {
+        "setNumber": set_number,
+        "setType": set_type,
+    }
+    if target_reps_min is not None:
+        payload["targetRepsMin"] = target_reps_min
+    if target_reps_max is not None:
+        payload["targetRepsMax"] = target_reps_max
+    if target_rir is not None:
+        payload["targetRir"] = target_rir
+    if target_weight is not None:
+        payload["targetWeightKg"] = target_weight
+    if weight_reduction_pct is not None:
+        payload["weightReductionPct"] = weight_reduction_pct
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addRoutineSet",
+                "routine_exercise_id": str(routine_exercise_id),
+                "input": payload,
+            },
+            command="routines add-set",
+        )
+        return
+
+    routine_exercise: RoutineExercise = _run(
+        ctx.routine_service.add_set(str(routine_exercise_id), payload)
+    )
+    _render(ctx, asdict(routine_exercise), command="routines add-set")
+
+
+@routines.command(name="update-set")
+@click.argument("set_id", type=click.UUID)
+@click.option("--set-number", type=click.IntRange(min=1), default=None)
+@click.option(
+    "--set-type",
+    type=click.Choice(["STANDARD", "DROPSET"], case_sensitive=True),
+    default=None,
+)
+@click.option("--target-reps-min", type=click.IntRange(min=1), default=None)
+@click.option("--target-reps-max", type=click.IntRange(min=1), default=None)
+@click.option("--target-rir", type=click.IntRange(min=0), default=None)
+@click.option("--target-weight", type=click.FloatRange(min=0), default=None)
+@click.option("--weight-reduction-pct", type=click.FloatRange(min=0, max=100), default=None)
+@click.option("--rest-seconds", type=click.IntRange(min=0), default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_routine_set(
+    ctx: CLIContext,
+    set_id: UUID,
+    set_number: int | None,
+    set_type: str | None,
+    target_reps_min: int | None,
+    target_reps_max: int | None,
+    target_rir: int | None,
+    target_weight: float | None,
+    weight_reduction_pct: float | None,
+    rest_seconds: int | None,
+    dry_run: bool,
+) -> None:
+    """Update one routine set."""
+
+    if (
+        target_reps_min is not None
+        and target_reps_max is not None
+        and target_reps_min > target_reps_max
+    ):
+        raise ValidationError("--target-reps-min cannot be greater than --target-reps-max")
+
+    payload: dict[str, object] = {}
+    if set_number is not None:
+        payload["setNumber"] = set_number
+    if set_type is not None:
+        payload["setType"] = set_type
+    if target_reps_min is not None:
+        payload["targetRepsMin"] = target_reps_min
+    if target_reps_max is not None:
+        payload["targetRepsMax"] = target_reps_max
+    if target_rir is not None:
+        payload["targetRir"] = target_rir
+    if target_weight is not None:
+        payload["targetWeightKg"] = target_weight
+    if weight_reduction_pct is not None:
+        payload["weightReductionPct"] = weight_reduction_pct
+    if rest_seconds is not None:
+        payload["restSeconds"] = rest_seconds
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateRoutineSet",
+                "id": str(set_id),
+                "input": payload,
+            },
+            command="routines update-set",
+        )
+        return
+
+    routine_set: RoutineSet = _run(ctx.routine_service.update_set(str(set_id), payload))
+    _render(ctx, asdict(routine_set), command="routines update-set")
+
+
+@routines.command(name="remove-set")
+@click.argument("set_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_routine_set(ctx: CLIContext, set_id: UUID, force: bool) -> None:
+    """Remove one set from a routine exercise."""
+
+    if not force:
+        raise ValidationError("Use --force to remove routine set")
+
+    deleted: bool = _run(ctx.routine_service.remove_set(str(set_id)))
+    _render(ctx, {"id": str(set_id), "deleted": deleted}, command="routines remove-set")

--- a/cli/src/workouter_cli/presentation/context.py
+++ b/cli/src/workouter_cli/presentation/context.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.workflow_service import WorkflowService
 from workouter_cli.infrastructure.config.schema import Config
@@ -21,6 +22,7 @@ class CLIContext:
     output_json: bool
     timeout: int
     exercise_service: ExerciseService
+    routine_service: RoutineService
     session_service: SessionService
     calendar_service: CalendarService
     workflow_service: WorkflowService

--- a/cli/tests/integration/test_routine_commands.py
+++ b/cli/tests/integration/test_routine_commands.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _routine_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Push Day",
+        "description": "Chest/Shoulders/Triceps",
+        "exercises": [],
+    }
+
+
+def _routine_exercise_payload() -> dict[str, object]:
+    return {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "exercise": {
+            "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "name": "Bench Press",
+        },
+        "order": 1,
+        "supersetGroup": None,
+        "restSeconds": 120,
+        "notes": None,
+        "sets": [],
+    }
+
+
+def _routine_set_payload() -> dict[str, object]:
+    return {
+        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "setNumber": 1,
+        "setType": "STANDARD",
+        "targetRepsMin": 8,
+        "targetRepsMax": 10,
+        "targetRir": 2,
+        "targetWeightKg": 80.0,
+        "weightReductionPct": None,
+        "restSeconds": 120,
+    }
+
+
+def test_routines_nested_commands_and_remove_validations(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "mutation AddRoutineExercise" in query:
+            calls.append("add-exercise")
+            return {"addRoutineExercise": _routine_payload()}
+        if "mutation UpdateRoutineExercise" in query:
+            calls.append("update-exercise")
+            return {"updateRoutineExercise": _routine_exercise_payload()}
+        if "mutation RemoveRoutineExercise" in query:
+            calls.append("remove-exercise")
+            return {"removeRoutineExercise": True}
+        if "mutation AddRoutineSet" in query:
+            calls.append("add-set")
+            payload = _routine_exercise_payload()
+            payload["sets"] = [_routine_set_payload()]
+            return {"addRoutineSet": payload}
+        if "mutation UpdateRoutineSet" in query:
+            calls.append("update-set")
+            return {"updateRoutineSet": _routine_set_payload()}
+        if "mutation RemoveRoutineSet" in query:
+            calls.append("remove-set")
+            return {"removeRoutineSet": True}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    add_exercise_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "add-exercise",
+            "11111111-1111-1111-1111-111111111111",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--order",
+            "1",
+            "--dry-run",
+        ],
+    )
+    assert add_exercise_dry_run.exit_code == 0
+    assert json.loads(add_exercise_dry_run.output.strip())["data"]["dry_run"] is True
+
+    add_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "add-exercise",
+            "11111111-1111-1111-1111-111111111111",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--order",
+            "1",
+        ],
+    )
+    assert add_exercise.exit_code == 0
+
+    update_exercise_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "update-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ],
+    )
+    assert update_exercise_validation.exit_code == 1
+
+    update_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "update-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--order",
+            "2",
+        ],
+    )
+    assert update_exercise.exit_code == 0
+
+    remove_exercise_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "remove-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ],
+    )
+    assert remove_exercise_validation.exit_code == 1
+
+    remove_exercise = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "remove-exercise",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--force",
+        ],
+    )
+    assert remove_exercise.exit_code == 0
+
+    add_set_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "add-set",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--set-number",
+            "1",
+            "--set-type",
+            "STANDARD",
+            "--dry-run",
+        ],
+    )
+    assert add_set_dry_run.exit_code == 0
+
+    add_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "add-set",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--set-number",
+            "1",
+            "--set-type",
+            "STANDARD",
+        ],
+    )
+    assert add_set.exit_code == 0
+
+    update_set_validation = runner.invoke(
+        cli,
+        ["--json", "routines", "update-set", "cccccccc-cccc-cccc-cccc-cccccccccccc"],
+    )
+    assert update_set_validation.exit_code == 1
+
+    update_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "update-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--target-reps-max",
+            "12",
+        ],
+    )
+    assert update_set.exit_code == 0
+
+    invalid_rep_range = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "update-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--target-reps-min",
+            "12",
+            "--target-reps-max",
+            "10",
+        ],
+    )
+    assert invalid_rep_range.exit_code == 1
+
+    remove_set_validation = runner.invoke(
+        cli,
+        ["--json", "routines", "remove-set", "cccccccc-cccc-cccc-cccc-cccccccccccc"],
+    )
+    assert remove_set_validation.exit_code == 1
+
+    remove_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "remove-set",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "--force",
+        ],
+    )
+    assert remove_set.exit_code == 0
+
+    assert calls == [
+        "add-exercise",
+        "update-exercise",
+        "remove-exercise",
+        "add-set",
+        "update-set",
+        "remove-set",
+    ]
+
+
+def test_routines_invalid_option_values_fail_fast() -> None:
+    runner = CliRunner(env=_base_env())
+
+    invalid_add_set = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "add-set",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--set-number",
+            "0",
+            "--set-type",
+            "STANDARD",
+        ],
+    )
+    assert invalid_add_set.exit_code == 2
+    assert "0 is not in the range x>=1" in invalid_add_set.output

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -20,3 +20,18 @@ def test_schema_command_outputs_valid_json_for_exercises_list() -> None:
     options = {item["name"] for item in payload["options"]}
     assert "--page" in options
     assert "--muscle-group-id" in options
+
+
+def test_schema_command_outputs_valid_json_for_routines_add_exercise() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "routines add-exercise"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "routines add-exercise"
+    assert payload["description"] == "Add exercise to a routine."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--exercise-id" in options
+    assert "--order" in options

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -96,6 +96,14 @@ def test_help_includes_sessions_command_group() -> None:
     assert "sessions" in result.output
 
 
+def test_help_includes_routines_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "routines" in result.output
+
+
 def test_schema_sessions_list_outputs_machine_readable_definition() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["schema", "sessions list"])
@@ -108,3 +116,17 @@ def test_schema_sessions_list_outputs_machine_readable_definition() -> None:
     option_names = {option["name"] for option in payload["options"]}
     assert "--status" in option_names
     assert "--mesocycle-id" in option_names
+
+
+def test_schema_routines_add_set_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "routines add-set"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "routines add-set"
+    assert payload["description"] == "Add set to a routine exercise."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--set-number" in option_names
+    assert "--set-type" in option_names

--- a/cli/tests/unit/test_routine_repository.py
+++ b/cli/tests/unit/test_routine_repository.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.mutations.routine import (
+    ADD_ROUTINE_EXERCISE,
+    ADD_ROUTINE_SET,
+    REMOVE_ROUTINE_EXERCISE,
+    REMOVE_ROUTINE_SET,
+    UPDATE_ROUTINE_EXERCISE,
+    UPDATE_ROUTINE_SET,
+)
+from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
+
+
+def _routine_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Push Day",
+        "description": "Chest/Shoulders/Triceps",
+        "exercises": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_add_exercise_maps_routine() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"addRoutineExercise": _routine_payload()})
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine = await repository.add_exercise(
+        "11111111-1111-1111-1111-111111111111",
+        {
+            "exerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "order": 1,
+        },
+    )
+
+    assert routine.name == "Push Day"
+    client.execute.assert_awaited_once_with(
+        ADD_ROUTINE_EXERCISE,
+        {
+            "routineId": "11111111-1111-1111-1111-111111111111",
+            "input": {
+                "exerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "order": 1,
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_exercise_maps_routine_exercise() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "updateRoutineExercise": {
+                "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "exercise": {
+                    "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "name": "Bench Press",
+                },
+                "order": 2,
+                "supersetGroup": None,
+                "restSeconds": 120,
+                "notes": "Heavy",
+                "sets": [],
+            }
+        }
+    )
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine_exercise = await repository.update_exercise(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2}
+    )
+
+    assert routine_exercise.order == 2
+    assert routine_exercise.exercise_name == "Bench Press"
+    client.execute.assert_awaited_once_with(
+        UPDATE_ROUTINE_EXERCISE,
+        {"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "input": {"order": 2}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_exercise_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removeRoutineExercise": True})
+
+    repository = GraphQLRoutineRepository(client=client)
+    deleted = await repository.remove_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_ROUTINE_EXERCISE,
+        {"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_add_set_maps_routine_exercise() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "addRoutineSet": {
+                "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "exercise": {
+                    "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "name": "Bench Press",
+                },
+                "order": 1,
+                "supersetGroup": None,
+                "restSeconds": 120,
+                "notes": None,
+                "sets": [
+                    {
+                        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "setNumber": 1,
+                        "setType": "STANDARD",
+                        "targetRepsMin": 8,
+                        "targetRepsMax": 10,
+                        "targetRir": 2,
+                        "targetWeightKg": 80.0,
+                        "weightReductionPct": None,
+                        "restSeconds": 120,
+                    }
+                ],
+            }
+        }
+    )
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine_exercise = await repository.add_set(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        {"setNumber": 1, "setType": "STANDARD"},
+    )
+
+    assert len(routine_exercise.sets) == 1
+    assert routine_exercise.sets[0].set_type == "STANDARD"
+    client.execute.assert_awaited_once_with(
+        ADD_ROUTINE_SET,
+        {
+            "routineExerciseId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "input": {"setNumber": 1, "setType": "STANDARD"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_set_maps_routine_set() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "updateRoutineSet": {
+                "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "setNumber": 1,
+                "setType": "STANDARD",
+                "targetRepsMin": 8,
+                "targetRepsMax": 12,
+                "targetRir": 1,
+                "targetWeightKg": 82.5,
+                "weightReductionPct": None,
+                "restSeconds": 120,
+            }
+        }
+    )
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine_set = await repository.update_set(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetRepsMax": 12}
+    )
+
+    assert routine_set.target_reps_max == 12
+    client.execute.assert_awaited_once_with(
+        UPDATE_ROUTINE_SET,
+        {"id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "input": {"targetRepsMax": 12}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_set_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removeRoutineSet": True})
+
+    repository = GraphQLRoutineRepository(client=client)
+    deleted = await repository.remove_set("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_ROUTINE_SET,
+        {"id": "cccccccc-cccc-cccc-cccc-cccccccccccc"},
+    )

--- a/cli/tests/unit/test_routine_service.py
+++ b/cli/tests/unit/test_routine_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.routine_service import RoutineService
+from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
+
+
+def _routine() -> Routine:
+    return Routine(
+        id="11111111-1111-1111-1111-111111111111",
+        name="Push Day",
+        description="Chest/Shoulders/Triceps",
+        exercises=(),
+    )
+
+
+def _routine_exercise() -> RoutineExercise:
+    return RoutineExercise(
+        id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        exercise_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        exercise_name="Bench Press",
+        order=1,
+        superset_group=None,
+        rest_seconds=120,
+        notes=None,
+        sets=(),
+    )
+
+
+def _routine_set() -> RoutineSet:
+    return RoutineSet(
+        id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+        set_number=1,
+        set_type="STANDARD",
+        target_reps_min=8,
+        target_reps_max=10,
+        target_rir=2,
+        target_weight_kg=80.0,
+        weight_reduction_pct=None,
+        rest_seconds=120,
+    )
+
+
+@pytest.mark.asyncio
+async def test_routine_service_add_and_update_nested_entities(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.add_exercise = AsyncMock(return_value=_routine())
+    repository.update_exercise = AsyncMock(return_value=_routine_exercise())
+    repository.add_set = AsyncMock(return_value=_routine_exercise())
+    repository.update_set = AsyncMock(return_value=_routine_set())
+    service = RoutineService(routine_repository=repository)
+
+    await service.add_exercise("11111111-1111-1111-1111-111111111111", {"order": 1})
+    await service.update_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2})
+    await service.add_set("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"setNumber": 1})
+    await service.update_set("cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetRepsMax": 12})
+
+    repository.add_exercise.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111", {"order": 1}
+    )
+    repository.update_exercise.assert_awaited_once_with(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"order": 2}
+    )
+    repository.add_set.assert_awaited_once_with(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {"setNumber": 1}
+    )
+    repository.update_set.assert_awaited_once_with(
+        "cccccccc-cccc-cccc-cccc-cccccccccccc", {"targetRepsMax": 12}
+    )
+
+
+@pytest.mark.asyncio
+async def test_routine_service_remove_nested_entities_delegate(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.remove_exercise = AsyncMock(return_value=True)
+    repository.remove_set = AsyncMock(return_value=True)
+    service = RoutineService(routine_repository=repository)
+
+    removed_exercise = await service.remove_exercise("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    removed_set = await service.remove_set("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+    assert removed_exercise is True
+    assert removed_set is True
+    repository.remove_exercise.assert_awaited_once_with("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    repository.remove_set.assert_awaited_once_with("cccccccc-cccc-cccc-cccc-cccccccccccc")


### PR DESCRIPTION
## Summary
- implement `routines add-exercise`, `update-exercise`, `remove-exercise`, `add-set`, `update-set`, and `remove-set` command handlers with non-interactive validation and `--dry-run` support
- add routine domain entities, repository/service wiring, GraphQL queries/mutations, and response mappers for routine nested composition operations
- register the new routines command group in CLI startup/context, and extend schema/help plus integration/unit tests to cover success paths, validation failures, and dry-run no-call behavior

## Testing
- `uv run pytest`