### PR TITLE
[CLI] Implement routines CRUD vertical slice

### DIFF
--- a/cli/src/workouter_cli/application/dto/__init__.py
+++ b/cli/src/workouter_cli/application/dto/__init__.py
@@ -2,10 +2,13 @@
 
 from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
 from workouter_cli.application.dto.pagination import PaginationInput, PaginationResult
+from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 
 __all__ = [
     "CreateExerciseInputDTO",
     "UpdateExerciseInputDTO",
+    "CreateRoutineInputDTO",
+    "UpdateRoutineInputDTO",
     "PaginationInput",
     "PaginationResult",
 ]

--- a/cli/src/workouter_cli/application/dto/routine.py
+++ b/cli/src/workouter_cli/application/dto/routine.py
@@ -1,0 +1,39 @@
+"""Routine input DTOs."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class CreateRoutineInputDTO(BaseModel):
+    """Validated payload for creating a routine."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            msg = "Routine name must not be blank"
+            raise ValueError(msg)
+        return value
+
+
+class UpdateRoutineInputDTO(BaseModel):
+    """Validated payload for updating a routine."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_optional_name_not_blank(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            msg = "Routine name must not be blank"
+            raise ValueError(msg)
+        return value

--- a/cli/src/workouter_cli/application/services/routine_service.py
+++ b/cli/src/workouter_cli/application/services/routine_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.repositories.routine import RoutineRepository
 
@@ -11,6 +12,25 @@ class RoutineService:
 
     def __init__(self, routine_repository: RoutineRepository) -> None:
         self.routine_repository = routine_repository
+
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Routine], dict[str, int]]:
+        return await self.routine_repository.list(page=page, page_size=page_size)
+
+    async def get(self, routine_id: str) -> Routine:
+        return await self.routine_repository.get(routine_id)
+
+    async def create(self, payload: CreateRoutineInputDTO) -> Routine:
+        data = payload.model_dump(exclude_none=True)
+        return await self.routine_repository.create(data)
+
+    async def update(self, routine_id: str, payload: UpdateRoutineInputDTO) -> Routine:
+        data = payload.model_dump(exclude_none=True)
+        return await self.routine_repository.update(routine_id, data)
+
+    async def delete(self, routine_id: str) -> bool:
+        return await self.routine_repository.delete(routine_id)
 
     async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
         return await self.routine_repository.add_exercise(routine_id, payload)

--- a/cli/src/workouter_cli/domain/repositories/routine.py
+++ b/cli/src/workouter_cli/domain/repositories/routine.py
@@ -10,6 +10,28 @@ from workouter_cli.domain.entities.routine import Routine, RoutineExercise, Rout
 class RoutineRepository(Protocol):
     """Persistence contract for routines."""
 
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Routine], dict[str, int]]:
+        """List routines and return items with pagination metadata."""
+        ...
+
+    async def get(self, routine_id: str) -> Routine:
+        """Get one routine by ID."""
+        ...
+
+    async def create(self, payload: dict[str, str | None]) -> Routine:
+        """Create one routine."""
+        ...
+
+    async def update(self, routine_id: str, payload: dict[str, str | None]) -> Routine:
+        """Update one routine."""
+        ...
+
+    async def delete(self, routine_id: str) -> bool:
+        """Delete one routine."""
+        ...
+
     async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
         """Add one exercise to a routine."""
         ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/routine.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/routine.py
@@ -37,6 +37,36 @@ weightReductionPct
 restSeconds
 """
 
+CREATE_ROUTINE = (
+    """
+mutation CreateRoutine($input: CreateRoutineInput!) {
+  createRoutine(input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_FIELDS
+)
+
+
+UPDATE_ROUTINE = (
+    """
+mutation UpdateRoutine($id: UUID!, $input: UpdateRoutineInput!) {
+  updateRoutine(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % ROUTINE_FIELDS
+)
+
+
+DELETE_ROUTINE = """
+mutation DeleteRoutine($id: UUID!) {
+  deleteRoutine(id: $id)
+}
+"""
+
 ADD_ROUTINE_EXERCISE = (
     """
 mutation AddRoutineExercise($routineId: UUID!, $input: AddRoutineExerciseInput!) {

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/routine.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/routine.py
@@ -27,3 +27,33 @@ exercises {
   }
 }
 """
+
+
+LIST_ROUTINES = (
+    """
+query ListRoutines($pagination: PaginationInput) {
+  routines(pagination: $pagination) {
+    items {
+      %s
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""
+    % ROUTINE_FIELDS
+)
+
+
+GET_ROUTINE = (
+    """
+query GetRoutine($id: UUID!) {
+  routine(id: $id) {
+    %s
+  }
+}
+"""
+    % ROUTINE_FIELDS
+)

--- a/cli/src/workouter_cli/infrastructure/repositories/routine.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/routine.py
@@ -11,13 +11,17 @@ from workouter_cli.infrastructure.graphql.mappers.response_mapper import (
     map_routine_set,
 )
 from workouter_cli.infrastructure.graphql.mutations.routine import (
+    CREATE_ROUTINE,
+    DELETE_ROUTINE,
     ADD_ROUTINE_EXERCISE,
     ADD_ROUTINE_SET,
     REMOVE_ROUTINE_EXERCISE,
     REMOVE_ROUTINE_SET,
+    UPDATE_ROUTINE,
     UPDATE_ROUTINE_EXERCISE,
     UPDATE_ROUTINE_SET,
 )
+from workouter_cli.infrastructure.graphql.queries.routine import GET_ROUTINE, LIST_ROUTINES
 
 
 class GraphQLRoutineRepository(RoutineRepository):
@@ -25,6 +29,45 @@ class GraphQLRoutineRepository(RoutineRepository):
 
     def __init__(self, client: GraphQLClient) -> None:
         self.client = client
+
+    async def list(
+        self, page: int = 1, page_size: int = 20
+    ) -> tuple[list[Routine], dict[str, int]]:
+        result = await self.client.execute(
+            LIST_ROUTINES,
+            {"pagination": {"page": page, "pageSize": page_size}},
+        )
+        payload = result["routines"]
+        items = [map_routine(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination
+
+    async def get(self, routine_id: str) -> Routine:
+        result = await self.client.execute(GET_ROUTINE, {"id": routine_id})
+        return map_routine(result["routine"])
+
+    async def create(self, payload: dict[str, str | None]) -> Routine:
+        result = await self.client.execute(CREATE_ROUTINE, {"input": payload})
+        return map_routine(result["createRoutine"])
+
+    async def update(self, routine_id: str, payload: dict[str, str | None]) -> Routine:
+        result = await self.client.execute(
+            UPDATE_ROUTINE,
+            {
+                "id": routine_id,
+                "input": payload,
+            },
+        )
+        return map_routine(result["updateRoutine"])
+
+    async def delete(self, routine_id: str) -> bool:
+        result = await self.client.execute(DELETE_ROUTINE, {"id": routine_id})
+        return bool(result["deleteRoutine"])
 
     async def add_exercise(self, routine_id: str, payload: dict[str, object]) -> Routine:
         result = await self.client.execute(

--- a/cli/src/workouter_cli/presentation/commands/routines.py
+++ b/cli/src/workouter_cli/presentation/commands/routines.py
@@ -9,8 +9,10 @@ from typing import Any, TypeVar
 from uuid import UUID
 
 import click
+from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console
 
+from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 from workouter_cli.application.formatters.factory import get_formatter
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.exceptions import ValidationError
@@ -38,9 +40,131 @@ def _require_any_update(payload: Mapping[str, object], message: str) -> None:
         raise ValidationError(message)
 
 
+def _routine_to_payload(routine: Routine) -> dict[str, object]:
+    return asdict(routine)
+
+
 @click.group(name="routines")
 def routines() -> None:
     """Routine composition commands."""
+
+
+@routines.command(name="list")
+@click.option("--page", type=click.IntRange(min=1), default=1, show_default=True)
+@click.option("--page-size", type=click.IntRange(min=1, max=100), default=20, show_default=True)
+@click.pass_obj
+def list_routines(ctx: CLIContext, page: int, page_size: int) -> None:
+    """List routines."""
+
+    items: list[Routine]
+    pagination: dict[str, int]
+    items, pagination = _run(ctx.routine_service.list(page=page, page_size=page_size))
+    payload = {
+        "items": [_routine_to_payload(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="routines list")
+
+
+@routines.command(name="get")
+@click.argument("routine_id", type=click.UUID)
+@click.pass_obj
+def get_routine(ctx: CLIContext, routine_id: UUID) -> None:
+    """Get one routine by ID."""
+
+    routine: Routine = _run(ctx.routine_service.get(str(routine_id)))
+    _render(ctx, _routine_to_payload(routine), command="routines get")
+
+
+@routines.command(name="create")
+@click.option("--name", required=True, type=str)
+@click.option("--description", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without creating")
+@click.pass_obj
+def create_routine(
+    ctx: CLIContext,
+    name: str,
+    description: str | None,
+    dry_run: bool,
+) -> None:
+    """Create routine."""
+
+    try:
+        dto = CreateRoutineInputDTO(name=name, description=description)
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid create payload: {message}") from error
+
+    payload = dto.model_dump(exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {"dry_run": True, "operation": "createRoutine", "input": payload},
+            command="routines create",
+        )
+        return
+
+    routine: Routine = _run(ctx.routine_service.create(dto))
+    _render(ctx, _routine_to_payload(routine), command="routines create")
+
+
+@routines.command(name="update")
+@click.argument("routine_id", type=click.UUID)
+@click.option("--name", type=str, default=None)
+@click.option("--description", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without updating")
+@click.pass_obj
+def update_routine(
+    ctx: CLIContext,
+    routine_id: UUID,
+    name: str | None,
+    description: str | None,
+    dry_run: bool,
+) -> None:
+    """Update routine."""
+
+    if name is None and description is None:
+        raise ValidationError("Provide at least one field to update")
+
+    try:
+        dto = UpdateRoutineInputDTO(name=name, description=description)
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid update payload: {message}") from error
+
+    payload = dto.model_dump(exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateRoutine",
+                "id": str(routine_id),
+                "input": payload,
+            },
+            command="routines update",
+        )
+        return
+
+    routine: Routine = _run(ctx.routine_service.update(str(routine_id), dto))
+    _render(ctx, _routine_to_payload(routine), command="routines update")
+
+
+@routines.command(name="delete")
+@click.argument("routine_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def delete_routine(ctx: CLIContext, routine_id: UUID, force: bool) -> None:
+    """Delete routine."""
+
+    if not force:
+        raise ValidationError("Use --force to delete routine")
+
+    deleted: bool = _run(ctx.routine_service.delete(str(routine_id)))
+    _render(ctx, {"id": str(routine_id), "deleted": deleted}, command="routines delete")
 
 
 @routines.command(name="add-exercise")

--- a/cli/tests/integration/test_routine_commands.py
+++ b/cli/tests/integration/test_routine_commands.py
@@ -54,6 +54,104 @@ def _routine_set_payload() -> dict[str, object]:
     }
 
 
+def _paginated_routines_payload() -> dict[str, object]:
+    return {
+        "items": [_routine_payload()],
+        "total": 1,
+        "page": 1,
+        "pageSize": 20,
+        "totalPages": 1,
+    }
+
+
+def test_routines_crud_commands_and_delete_validation(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query ListRoutines" in query:
+            calls.append("list")
+            return {"routines": _paginated_routines_payload()}
+        if "query GetRoutine" in query:
+            calls.append("get")
+            return {"routine": _routine_payload()}
+        if "mutation CreateRoutine" in query:
+            calls.append("create")
+            return {"createRoutine": _routine_payload()}
+        if "mutation UpdateRoutine" in query:
+            calls.append("update")
+            return {"updateRoutine": _routine_payload()}
+        if "mutation DeleteRoutine" in query:
+            calls.append("delete")
+            return {"deleteRoutine": True}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    list_result = runner.invoke(
+        cli, ["--json", "routines", "list", "--page", "1", "--page-size", "20"]
+    )
+    assert list_result.exit_code == 0
+    list_payload = json.loads(list_result.output.strip())
+    assert list_payload["data"]["total"] == 1
+
+    get_result = runner.invoke(
+        cli,
+        ["--json", "routines", "get", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert get_result.exit_code == 0
+
+    create_dry_run = runner.invoke(
+        cli,
+        ["--json", "routines", "create", "--name", "Push Day", "--dry-run"],
+    )
+    assert create_dry_run.exit_code == 0
+    assert json.loads(create_dry_run.output.strip())["data"]["dry_run"] is True
+
+    create_result = runner.invoke(
+        cli,
+        ["--json", "routines", "create", "--name", "Push Day"],
+    )
+    assert create_result.exit_code == 0
+
+    update_validation = runner.invoke(
+        cli,
+        ["--json", "routines", "update", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert update_validation.exit_code == 1
+
+    update_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "routines",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--description",
+            "Updated",
+        ],
+    )
+    assert update_result.exit_code == 0
+
+    delete_validation = runner.invoke(
+        cli,
+        ["--json", "routines", "delete", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert delete_validation.exit_code == 1
+
+    delete_result = runner.invoke(
+        cli,
+        ["--json", "routines", "delete", "11111111-1111-1111-1111-111111111111", "--force"],
+    )
+    assert delete_result.exit_code == 0
+
+    assert calls == ["list", "get", "create", "update", "delete"]
+
+
 def test_routines_nested_commands_and_remove_validations(mocker) -> None:  # type: ignore[no-untyped-def]
     calls: list[str] = []
 

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -35,3 +35,18 @@ def test_schema_command_outputs_valid_json_for_routines_add_exercise() -> None:
     options = {item["name"] for item in payload["options"]}
     assert "--exercise-id" in options
     assert "--order" in options
+
+
+def test_schema_command_outputs_valid_json_for_routines_crud_list() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "routines list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "routines list"
+    assert payload["description"] == "List routines."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--page" in options
+    assert "--page-size" in options

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -130,3 +130,17 @@ def test_schema_routines_add_set_outputs_machine_readable_definition() -> None:
     option_names = {option["name"] for option in payload["options"]}
     assert "--set-number" in option_names
     assert "--set-type" in option_names
+
+
+def test_schema_routines_list_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "routines list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "routines list"
+    assert payload["description"] == "List routines."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--page" in option_names
+    assert "--page-size" in option_names

--- a/cli/tests/unit/test_routine_repository.py
+++ b/cli/tests/unit/test_routine_repository.py
@@ -5,13 +5,17 @@ from unittest.mock import AsyncMock
 import pytest
 
 from workouter_cli.infrastructure.graphql.mutations.routine import (
+    CREATE_ROUTINE,
+    DELETE_ROUTINE,
     ADD_ROUTINE_EXERCISE,
     ADD_ROUTINE_SET,
     REMOVE_ROUTINE_EXERCISE,
     REMOVE_ROUTINE_SET,
+    UPDATE_ROUTINE,
     UPDATE_ROUTINE_EXERCISE,
     UPDATE_ROUTINE_SET,
 )
+from workouter_cli.infrastructure.graphql.queries.routine import GET_ROUTINE, LIST_ROUTINES
 from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 
 
@@ -22,6 +26,98 @@ def _routine_payload() -> dict[str, object]:
         "description": "Chest/Shoulders/Triceps",
         "exercises": [],
     }
+
+
+@pytest.mark.asyncio
+async def test_repository_list_maps_routines_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "routines": {
+                "items": [_routine_payload()],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLRoutineRepository(client=client)
+    items, pagination = await repository.list(page=1, page_size=20)
+
+    assert len(items) == 1
+    assert items[0].name == "Push Day"
+    assert pagination == {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1}
+    client.execute.assert_awaited_once_with(
+        LIST_ROUTINES,
+        {"pagination": {"page": 1, "pageSize": 20}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_get_maps_routine() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"routine": _routine_payload()})
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine = await repository.get("11111111-1111-1111-1111-111111111111")
+
+    assert routine.id == "11111111-1111-1111-1111-111111111111"
+    client.execute.assert_awaited_once_with(
+        GET_ROUTINE,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_create_maps_routine() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"createRoutine": _routine_payload()})
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine = await repository.create({"name": "Push Day"})
+
+    assert routine.name == "Push Day"
+    client.execute.assert_awaited_once_with(
+        CREATE_ROUTINE,
+        {"input": {"name": "Push Day"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_maps_routine() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updateRoutine": _routine_payload()})
+
+    repository = GraphQLRoutineRepository(client=client)
+    routine = await repository.update(
+        "11111111-1111-1111-1111-111111111111", {"description": "Updated"}
+    )
+
+    assert routine.id == "11111111-1111-1111-1111-111111111111"
+    client.execute.assert_awaited_once_with(
+        UPDATE_ROUTINE,
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "input": {"description": "Updated"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_delete_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"deleteRoutine": True})
+
+    repository = GraphQLRoutineRepository(client=client)
+    deleted = await repository.delete("11111111-1111-1111-1111-111111111111")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        DELETE_ROUTINE,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )
 
 
 @pytest.mark.asyncio

--- a/cli/tests/unit/test_routine_service.py
+++ b/cli/tests/unit/test_routine_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 
@@ -42,6 +43,44 @@ def _routine_set() -> RoutineSet:
         weight_reduction_pct=None,
         rest_seconds=120,
     )
+
+
+@pytest.mark.asyncio
+async def test_routine_service_crud_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.list = AsyncMock(
+        return_value=([_routine()], {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1})
+    )
+    repository.get = AsyncMock(return_value=_routine())
+    repository.create = AsyncMock(return_value=_routine())
+    repository.update = AsyncMock(return_value=_routine())
+    repository.delete = AsyncMock(return_value=True)
+    service = RoutineService(routine_repository=repository)
+
+    items, pagination = await service.list(page=1, page_size=20)
+    fetched = await service.get("11111111-1111-1111-1111-111111111111")
+    created = await service.create(CreateRoutineInputDTO(name="Push Day"))
+    updated = await service.update(
+        "11111111-1111-1111-1111-111111111111",
+        UpdateRoutineInputDTO(description="Updated"),
+    )
+    deleted = await service.delete("11111111-1111-1111-1111-111111111111")
+
+    assert len(items) == 1
+    assert pagination["total"] == 1
+    assert fetched.name == "Push Day"
+    assert created.name == "Push Day"
+    assert updated.id == "11111111-1111-1111-1111-111111111111"
+    assert deleted is True
+
+    repository.list.assert_awaited_once_with(page=1, page_size=20)
+    repository.get.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+    repository.create.assert_awaited_once_with({"name": "Push Day"})
+    repository.update.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111",
+        {"description": "Updated"},
+    )
+    repository.delete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- implement `routines` CRUD commands (`list`, `get`, `create`, `update`, `delete`) with local validation, dry-run support, and consistent JSON/table output envelopes
- add routines CRUD support through clean architecture layers (DTOs, service orchestration, repository protocol, GraphQL queries/mutations, and GraphQL repository implementation)
- extend unit and integration coverage for routines CRUD flows and schema command introspection for the new routines CRUD surface

## Testing
- `uv run pytest -q --tb=short --disable-warnings`

Closes #17