### PR TITLE
[CLI] Implement mesocycles CRUD vertical slice

### DIFF
--- a/cli/src/workouter_cli/application/dto/__init__.py
+++ b/cli/src/workouter_cli/application/dto/__init__.py
@@ -1,12 +1,15 @@
 """Application DTO package."""
 
 from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
+from workouter_cli.application.dto.mesocycle import CreateMesocycleInputDTO, UpdateMesocycleInputDTO
 from workouter_cli.application.dto.pagination import PaginationInput, PaginationResult
 from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 
 __all__ = [
     "CreateExerciseInputDTO",
     "UpdateExerciseInputDTO",
+    "CreateMesocycleInputDTO",
+    "UpdateMesocycleInputDTO",
     "CreateRoutineInputDTO",
     "UpdateRoutineInputDTO",
     "PaginationInput",

--- a/cli/src/workouter_cli/application/dto/mesocycle.py
+++ b/cli/src/workouter_cli/application/dto/mesocycle.py
@@ -1,0 +1,56 @@
+"""Mesocycle input DTOs."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class CreateMesocycleInputDTO(BaseModel):
+    """Validated payload for creating a mesocycle."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    start_date: date = Field(alias="startDate")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            msg = "Mesocycle name must not be blank"
+            raise ValueError(msg)
+        return value
+
+
+class UpdateMesocycleInputDTO(BaseModel):
+    """Validated payload for updating a mesocycle."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    start_date: date | None = Field(default=None, alias="startDate")
+    end_date: date | None = Field(default=None, alias="endDate")
+    status: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_optional_name_not_blank(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            msg = "Mesocycle name must not be blank"
+            raise ValueError(msg)
+        return value
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        allowed = {"PLANNED", "ACTIVE", "COMPLETED"}
+        if value not in allowed:
+            msg = "Mesocycle status must be one of: PLANNED, ACTIVE, COMPLETED"
+            raise ValueError(msg)
+        return value

--- a/cli/src/workouter_cli/application/services/__init__.py
+++ b/cli/src/workouter_cli/application/services/__init__.py
@@ -1,6 +1,7 @@
 """Application services package."""
 
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.routine_service import RoutineService
@@ -8,6 +9,7 @@ from workouter_cli.application.services.workflow_service import WorkflowService
 
 __all__ = [
     "ExerciseService",
+    "MesocycleService",
     "SessionService",
     "CalendarService",
     "RoutineService",

--- a/cli/src/workouter_cli/application/services/mesocycle_service.py
+++ b/cli/src/workouter_cli/application/services/mesocycle_service.py
@@ -1,0 +1,43 @@
+"""Mesocycle application service."""
+
+from __future__ import annotations
+
+from workouter_cli.application.dto.mesocycle import (
+    CreateMesocycleInputDTO,
+    UpdateMesocycleInputDTO,
+)
+from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
+
+
+class MesocycleService:
+    """Mesocycle lifecycle use-cases orchestration."""
+
+    def __init__(self, mesocycle_repository: MesocycleRepository) -> None:
+        self.mesocycle_repository = mesocycle_repository
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Mesocycle], dict[str, int]]:
+        return await self.mesocycle_repository.list(
+            page=page,
+            page_size=page_size,
+            status=status,
+        )
+
+    async def get(self, mesocycle_id: str) -> Mesocycle:
+        return await self.mesocycle_repository.get(mesocycle_id)
+
+    async def create(self, payload: CreateMesocycleInputDTO) -> Mesocycle:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.create(data)
+
+    async def update(self, mesocycle_id: str, payload: UpdateMesocycleInputDTO) -> Mesocycle:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.update(mesocycle_id, data)
+
+    async def delete(self, mesocycle_id: str) -> bool:
+        return await self.mesocycle_repository.delete(mesocycle_id)

--- a/cli/src/workouter_cli/domain/entities/__init__.py
+++ b/cli/src/workouter_cli/domain/entities/__init__.py
@@ -2,6 +2,7 @@
 
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+from workouter_cli.domain.entities.mesocycle import Mesocycle, MesocycleWeek
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
@@ -9,6 +10,8 @@ __all__ = [
     "MuscleGroup",
     "ExerciseMuscleGroup",
     "Exercise",
+    "MesocycleWeek",
+    "Mesocycle",
     "RoutineSet",
     "RoutineExercise",
     "Routine",

--- a/cli/src/workouter_cli/domain/entities/mesocycle.py
+++ b/cli/src/workouter_cli/domain/entities/mesocycle.py
@@ -1,0 +1,29 @@
+"""Mesocycle domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class MesocycleWeek:
+    """Mesocycle week planning details."""
+
+    id: str
+    week_number: int
+    week_type: str
+    start_date: str
+    end_date: str
+
+
+@dataclass(slots=True, frozen=True)
+class Mesocycle:
+    """Mesocycle aggregate root."""
+
+    id: str
+    name: str
+    description: str | None
+    start_date: str
+    end_date: str | None
+    status: str
+    weeks: tuple[MesocycleWeek, ...]

--- a/cli/src/workouter_cli/domain/repositories/__init__.py
+++ b/cli/src/workouter_cli/domain/repositories/__init__.py
@@ -1,12 +1,14 @@
 """Domain repository protocols package."""
 
 from workouter_cli.domain.repositories.exercise import ExerciseRepository
+from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
 from workouter_cli.domain.repositories.session import SessionRepository
 from workouter_cli.domain.repositories.calendar import CalendarRepository
 from workouter_cli.domain.repositories.routine import RoutineRepository
 
 __all__ = [
     "ExerciseRepository",
+    "MesocycleRepository",
     "SessionRepository",
     "CalendarRepository",
     "RoutineRepository",

--- a/cli/src/workouter_cli/domain/repositories/mesocycle.py
+++ b/cli/src/workouter_cli/domain/repositories/mesocycle.py
@@ -1,0 +1,36 @@
+"""Mesocycle repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.mesocycle import Mesocycle
+
+
+class MesocycleRepository(Protocol):
+    """Persistence contract for mesocycles."""
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Mesocycle], dict[str, int]]:
+        """List mesocycles and return items with pagination metadata."""
+        ...
+
+    async def get(self, mesocycle_id: str) -> Mesocycle:
+        """Get one mesocycle by ID."""
+        ...
+
+    async def create(self, payload: dict[str, str]) -> Mesocycle:
+        """Create one mesocycle."""
+        ...
+
+    async def update(self, mesocycle_id: str, payload: dict[str, str]) -> Mesocycle:
+        """Update one mesocycle."""
+        ...
+
+    async def delete(self, mesocycle_id: str) -> bool:
+        """Delete one mesocycle."""
+        ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
+from workouter_cli.domain.entities.mesocycle import Mesocycle, MesocycleWeek
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
@@ -149,6 +150,32 @@ def map_routine(data: dict[str, Any]) -> Routine:
         name=str(data["name"]),
         description=str(data["description"]) if data.get("description") is not None else None,
         exercises=tuple(map_routine_exercise(item) for item in data.get("exercises", [])),
+    )
+
+
+def map_mesocycle_week(data: dict[str, Any]) -> MesocycleWeek:
+    """Map GraphQL mesocycle week payload to domain entity."""
+
+    return MesocycleWeek(
+        id=str(data["id"]),
+        week_number=int(data["weekNumber"]),
+        week_type=str(data["weekType"]),
+        start_date=str(data["startDate"]),
+        end_date=str(data["endDate"]),
+    )
+
+
+def map_mesocycle(data: dict[str, Any]) -> Mesocycle:
+    """Map GraphQL mesocycle payload to domain entity."""
+
+    return Mesocycle(
+        id=str(data["id"]),
+        name=str(data["name"]),
+        description=str(data["description"]) if data.get("description") is not None else None,
+        start_date=str(data["startDate"]),
+        end_date=str(data["endDate"]) if data.get("endDate") is not None else None,
+        status=str(data["status"]),
+        weeks=tuple(map_mesocycle_week(item) for item in data.get("weeks", [])),
     )
 
 

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -5,6 +5,11 @@ from workouter_cli.infrastructure.graphql.mutations.exercise import (
     DELETE_EXERCISE,
     UPDATE_EXERCISE,
 )
+from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    CREATE_MESOCYCLE,
+    DELETE_MESOCYCLE,
+    UPDATE_MESOCYCLE,
+)
 from workouter_cli.infrastructure.graphql.mutations.routine import (
     ADD_ROUTINE_EXERCISE,
     ADD_ROUTINE_SET,
@@ -32,6 +37,9 @@ __all__ = [
     "CREATE_EXERCISE",
     "UPDATE_EXERCISE",
     "DELETE_EXERCISE",
+    "CREATE_MESOCYCLE",
+    "UPDATE_MESOCYCLE",
+    "DELETE_MESOCYCLE",
     "ADD_ROUTINE_EXERCISE",
     "UPDATE_ROUTINE_EXERCISE",
     "REMOVE_ROUTINE_EXERCISE",

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/mesocycle.py
@@ -1,0 +1,31 @@
+"""Mesocycle GraphQL mutations."""
+
+from workouter_cli.infrastructure.graphql.queries.mesocycle import MESOCYCLE_FIELDS
+
+CREATE_MESOCYCLE = (
+    """
+mutation CreateMesocycle($input: CreateMesocycleInput!) {
+  createMesocycle(input: $input) {
+    %s
+  }
+}
+"""
+    % MESOCYCLE_FIELDS
+)
+
+UPDATE_MESOCYCLE = (
+    """
+mutation UpdateMesocycle($id: UUID!, $input: UpdateMesocycleInput!) {
+  updateMesocycle(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % MESOCYCLE_FIELDS
+)
+
+DELETE_MESOCYCLE = """
+mutation DeleteMesocycle($id: UUID!) {
+  deleteMesocycle(id: $id)
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -2,6 +2,7 @@
 
 from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
 from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
+from workouter_cli.infrastructure.graphql.queries.mesocycle import GET_MESOCYCLE, LIST_MESOCYCLES
 from workouter_cli.infrastructure.graphql.queries.routine import ROUTINE_FIELDS
 from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 
@@ -9,6 +10,8 @@ __all__ = [
     "GET_EXERCISE",
     "LIST_EXERCISES",
     "CALENDAR_DAY",
+    "LIST_MESOCYCLES",
+    "GET_MESOCYCLE",
     "ROUTINE_FIELDS",
     "LIST_SESSIONS",
     "GET_SESSION",

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/mesocycle.py
@@ -1,0 +1,45 @@
+"""Mesocycle GraphQL queries."""
+
+MESOCYCLE_FIELDS = """
+id
+name
+description
+startDate
+endDate
+status
+weeks {
+  id
+  weekNumber
+  weekType
+  startDate
+  endDate
+}
+"""
+
+LIST_MESOCYCLES = (
+    """
+query ListMesocycles($pagination: PaginationInput, $status: MesocycleStatus) {
+  mesocycles(pagination: $pagination, status: $status) {
+    items {
+      %s
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""
+    % MESOCYCLE_FIELDS
+)
+
+GET_MESOCYCLE = (
+    """
+query GetMesocycle($id: UUID!) {
+  mesocycle(id: $id) {
+    %s
+  }
+}
+"""
+    % MESOCYCLE_FIELDS
+)

--- a/cli/src/workouter_cli/infrastructure/repositories/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/__init__.py
@@ -1,12 +1,14 @@
 """Infrastructure repository implementations package."""
 
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
 from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 
 __all__ = [
     "GraphQLExerciseRepository",
+    "GraphQLMesocycleRepository",
     "GraphQLSessionRepository",
     "GraphQLCalendarRepository",
     "GraphQLRoutineRepository",

--- a/cli/src/workouter_cli/infrastructure/repositories/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/mesocycle.py
@@ -1,0 +1,69 @@
+"""GraphQL-backed mesocycle repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_mesocycle
+from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    CREATE_MESOCYCLE,
+    DELETE_MESOCYCLE,
+    UPDATE_MESOCYCLE,
+)
+from workouter_cli.infrastructure.graphql.queries.mesocycle import (
+    GET_MESOCYCLE,
+    LIST_MESOCYCLES,
+)
+
+
+class GraphQLMesocycleRepository(MesocycleRepository):
+    """Mesocycle repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+    ) -> tuple[list[Mesocycle], dict[str, int]]:
+        result = await self.client.execute(
+            LIST_MESOCYCLES,
+            {
+                "pagination": {"page": page, "pageSize": page_size},
+                "status": status,
+            },
+        )
+        payload = result["mesocycles"]
+        items = [map_mesocycle(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination
+
+    async def get(self, mesocycle_id: str) -> Mesocycle:
+        result = await self.client.execute(GET_MESOCYCLE, {"id": mesocycle_id})
+        return map_mesocycle(result["mesocycle"])
+
+    async def create(self, payload: dict[str, str]) -> Mesocycle:
+        result = await self.client.execute(CREATE_MESOCYCLE, {"input": payload})
+        return map_mesocycle(result["createMesocycle"])
+
+    async def update(self, mesocycle_id: str, payload: dict[str, str]) -> Mesocycle:
+        result = await self.client.execute(
+            UPDATE_MESOCYCLE,
+            {
+                "id": mesocycle_id,
+                "input": payload,
+            },
+        )
+        return map_mesocycle(result["updateMesocycle"])
+
+    async def delete(self, mesocycle_id: str) -> bool:
+        result = await self.client.execute(DELETE_MESOCYCLE, {"id": mesocycle_id})
+        return bool(result["deleteMesocycle"])

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from workouter_cli.application.formatters.factory import get_formatter
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.workflow_service import WorkflowService
@@ -19,9 +20,11 @@ from workouter_cli.infrastructure.config.loader import ConfigError, load_config
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
 from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.presentation.commands.exercises import exercises
+from workouter_cli.presentation.commands.mesocycles import mesocycles
 from workouter_cli.presentation.commands.routines import routines
 from workouter_cli.presentation.commands.sessions import sessions
 from workouter_cli.presentation.commands.workout import workout
@@ -188,10 +191,12 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
             url=str(config.api_url), api_key=config.api_key, timeout=effective_timeout
         )
         exercise_repository = GraphQLExerciseRepository(client=client)
+        mesocycle_repository = GraphQLMesocycleRepository(client=client)
         routine_repository = GraphQLRoutineRepository(client=client)
         session_repository = GraphQLSessionRepository(client=client)
         calendar_repository = GraphQLCalendarRepository(client=client)
         exercise_service = ExerciseService(exercise_repository=exercise_repository)
+        mesocycle_service = MesocycleService(mesocycle_repository=mesocycle_repository)
         routine_service = RoutineService(routine_repository=routine_repository)
         session_service = SessionService(session_repository=session_repository)
         calendar_service = CalendarService(calendar_repository=calendar_repository)
@@ -205,6 +210,7 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
             output_json=output_json,
             timeout=effective_timeout,
             exercise_service=exercise_service,
+            mesocycle_service=mesocycle_service,
             routine_service=routine_service,
             session_service=session_service,
             calendar_service=calendar_service,
@@ -251,6 +257,7 @@ def raise_auth() -> None:
 
 
 cli.add_command(exercises)
+cli.add_command(mesocycles)
 cli.add_command(routines)
 cli.add_command(sessions)
 cli.add_command(workout)

--- a/cli/src/workouter_cli/presentation/commands/mesocycles.py
+++ b/cli/src/workouter_cli/presentation/commands/mesocycles.py
@@ -1,0 +1,205 @@
+"""Mesocycles command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import asdict
+from datetime import date, datetime
+from typing import Any, TypeVar
+from uuid import UUID
+
+import click
+from pydantic import ValidationError as PydanticValidationError
+from rich.console import Console
+
+from workouter_cli.application.dto.mesocycle import (
+    CreateMesocycleInputDTO,
+    UpdateMesocycleInputDTO,
+)
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.exceptions import ValidationError
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+def _mesocycle_to_payload(mesocycle: Mesocycle) -> dict[str, object]:
+    return asdict(mesocycle)
+
+
+def _to_date(value: datetime | None) -> date | None:
+    return value.date() if value is not None else None
+
+
+@click.group(name="mesocycles")
+def mesocycles() -> None:
+    """Mesocycle CRUD commands."""
+
+
+@mesocycles.command(name="list")
+@click.option("--page", type=click.IntRange(min=1), default=1, show_default=True)
+@click.option("--page-size", type=click.IntRange(min=1, max=100), default=20, show_default=True)
+@click.option(
+    "--status",
+    type=click.Choice(["PLANNED", "ACTIVE", "COMPLETED"], case_sensitive=True),
+    default=None,
+)
+@click.pass_obj
+def list_mesocycles(ctx: CLIContext, page: int, page_size: int, status: str | None) -> None:
+    """List mesocycles."""
+
+    items: list[Mesocycle]
+    pagination: dict[str, int]
+    items, pagination = _run(
+        ctx.mesocycle_service.list(page=page, page_size=page_size, status=status)
+    )
+    payload = {
+        "items": [_mesocycle_to_payload(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="mesocycles list")
+
+
+@mesocycles.command(name="get")
+@click.argument("mesocycle_id", type=click.UUID)
+@click.pass_obj
+def get_mesocycle(ctx: CLIContext, mesocycle_id: UUID) -> None:
+    """Get one mesocycle by ID."""
+
+    mesocycle: Mesocycle = _run(ctx.mesocycle_service.get(str(mesocycle_id)))
+    _render(ctx, _mesocycle_to_payload(mesocycle), command="mesocycles get")
+
+
+@mesocycles.command(name="create")
+@click.option("--name", required=True, type=str)
+@click.option("--description", type=str, default=None)
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.option("--dry-run", is_flag=True, help="Validate without creating")
+@click.pass_obj
+def create_mesocycle(
+    ctx: CLIContext,
+    name: str,
+    description: str | None,
+    start_date: datetime,
+    dry_run: bool,
+) -> None:
+    """Create mesocycle."""
+
+    try:
+        dto = CreateMesocycleInputDTO(
+            name=name,
+            description=description,
+            startDate=start_date.date(),
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid create payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {"dry_run": True, "operation": "createMesocycle", "input": payload},
+            command="mesocycles create",
+        )
+        return
+
+    mesocycle: Mesocycle = _run(ctx.mesocycle_service.create(dto))
+    _render(ctx, _mesocycle_to_payload(mesocycle), command="mesocycles create")
+
+
+@mesocycles.command(name="update")
+@click.argument("mesocycle_id", type=click.UUID)
+@click.option("--name", type=str, default=None)
+@click.option("--description", type=str, default=None)
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--end-date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option(
+    "--status",
+    type=click.Choice(["PLANNED", "ACTIVE", "COMPLETED"], case_sensitive=True),
+    default=None,
+)
+@click.option("--dry-run", is_flag=True, help="Validate without updating")
+@click.pass_obj
+def update_mesocycle(
+    ctx: CLIContext,
+    mesocycle_id: UUID,
+    name: str | None,
+    description: str | None,
+    start_date: datetime | None,
+    end_date: datetime | None,
+    status: str | None,
+    dry_run: bool,
+) -> None:
+    """Update mesocycle."""
+
+    if (
+        name is None
+        and description is None
+        and start_date is None
+        and end_date is None
+        and status is None
+    ):
+        raise ValidationError("Provide at least one field to update")
+
+    try:
+        dto = UpdateMesocycleInputDTO(
+            name=name,
+            description=description,
+            startDate=_to_date(start_date),
+            endDate=_to_date(end_date),
+            status=status,
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid update payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateMesocycle",
+                "id": str(mesocycle_id),
+                "input": payload,
+            },
+            command="mesocycles update",
+        )
+        return
+
+    mesocycle: Mesocycle = _run(ctx.mesocycle_service.update(str(mesocycle_id), dto))
+    _render(ctx, _mesocycle_to_payload(mesocycle), command="mesocycles update")
+
+
+@mesocycles.command(name="delete")
+@click.argument("mesocycle_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def delete_mesocycle(ctx: CLIContext, mesocycle_id: UUID, force: bool) -> None:
+    """Delete mesocycle."""
+
+    if not force:
+        raise ValidationError("Use --force to delete mesocycle")
+
+    deleted: bool = _run(ctx.mesocycle_service.delete(str(mesocycle_id)))
+    _render(ctx, {"id": str(mesocycle_id), "deleted": deleted}, command="mesocycles delete")

--- a/cli/src/workouter_cli/presentation/context.py
+++ b/cli/src/workouter_cli/presentation/context.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.workflow_service import WorkflowService
@@ -22,6 +23,7 @@ class CLIContext:
     output_json: bool
     timeout: int
     exercise_service: ExerciseService
+    mesocycle_service: MesocycleService
     routine_service: RoutineService
     session_service: SessionService
     calendar_service: CalendarService

--- a/cli/tests/integration/test_mesocycle_commands.py
+++ b/cli/tests/integration/test_mesocycle_commands.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _mesocycle_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Hypertrophy Block",
+        "description": "Upper focus",
+        "startDate": "2026-01-01",
+        "endDate": None,
+        "status": "PLANNED",
+        "weeks": [],
+    }
+
+
+def _paginated_mesocycles_payload() -> dict[str, object]:
+    return {
+        "items": [_mesocycle_payload()],
+        "total": 1,
+        "page": 1,
+        "pageSize": 20,
+        "totalPages": 1,
+    }
+
+
+def test_mesocycles_crud_commands_and_delete_validation(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query ListMesocycles" in query:
+            calls.append("list")
+            return {"mesocycles": _paginated_mesocycles_payload()}
+        if "query GetMesocycle" in query:
+            calls.append("get")
+            return {"mesocycle": _mesocycle_payload()}
+        if "mutation CreateMesocycle" in query:
+            calls.append("create")
+            return {"createMesocycle": _mesocycle_payload()}
+        if "mutation UpdateMesocycle" in query:
+            calls.append("update")
+            return {"updateMesocycle": _mesocycle_payload()}
+        if "mutation DeleteMesocycle" in query:
+            calls.append("delete")
+            return {"deleteMesocycle": True}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    list_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "list",
+            "--page",
+            "1",
+            "--page-size",
+            "20",
+            "--status",
+            "PLANNED",
+        ],
+    )
+    assert list_result.exit_code == 0
+    list_payload = json.loads(list_result.output.strip())
+    assert list_payload["data"]["total"] == 1
+
+    get_result = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "get", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert get_result.exit_code == 0
+
+    create_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "create",
+            "--name",
+            "Hypertrophy Block",
+            "--start-date",
+            "2026-01-01",
+            "--dry-run",
+        ],
+    )
+    assert create_dry_run.exit_code == 0
+    assert json.loads(create_dry_run.output.strip())["data"]["dry_run"] is True
+
+    create_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "create",
+            "--name",
+            "Hypertrophy Block",
+            "--start-date",
+            "2026-01-01",
+        ],
+    )
+    assert create_result.exit_code == 0
+
+    update_validation = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "update", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert update_validation.exit_code == 1
+
+    update_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--status",
+            "ACTIVE",
+            "--end-date",
+            "2026-02-28",
+        ],
+    )
+    assert update_result.exit_code == 0
+
+    delete_validation = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "delete", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert delete_validation.exit_code == 1
+
+    delete_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "delete",
+            "11111111-1111-1111-1111-111111111111",
+            "--force",
+        ],
+    )
+    assert delete_result.exit_code == 0
+
+    assert calls == ["list", "get", "create", "update", "delete"]

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -50,3 +50,18 @@ def test_schema_command_outputs_valid_json_for_routines_crud_list() -> None:
     options = {item["name"] for item in payload["options"]}
     assert "--page" in options
     assert "--page-size" in options
+
+
+def test_schema_command_outputs_valid_json_for_mesocycles_list() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "mesocycles list"
+    assert payload["description"] == "List mesocycles."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--page" in options
+    assert "--status" in options

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -104,6 +104,14 @@ def test_help_includes_routines_command_group() -> None:
     assert "routines" in result.output
 
 
+def test_help_includes_mesocycles_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "mesocycles" in result.output
+
+
 def test_schema_sessions_list_outputs_machine_readable_definition() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["schema", "sessions list"])
@@ -144,3 +152,17 @@ def test_schema_routines_list_outputs_machine_readable_definition() -> None:
     option_names = {option["name"] for option in payload["options"]}
     assert "--page" in option_names
     assert "--page-size" in option_names
+
+
+def test_schema_mesocycles_list_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles list"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "mesocycles list"
+    assert payload["description"] == "List mesocycles."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--page" in option_names
+    assert "--status" in option_names

--- a/cli/tests/unit/test_mesocycle_repository.py
+++ b/cli/tests/unit/test_mesocycle_repository.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    CREATE_MESOCYCLE,
+    DELETE_MESOCYCLE,
+    UPDATE_MESOCYCLE,
+)
+from workouter_cli.infrastructure.graphql.queries.mesocycle import GET_MESOCYCLE, LIST_MESOCYCLES
+from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
+
+
+def _mesocycle_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "Hypertrophy Block",
+        "description": "Upper focus",
+        "startDate": "2026-01-01",
+        "endDate": None,
+        "status": "PLANNED",
+        "weeks": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_list_maps_mesocycles_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "mesocycles": {
+                "items": [_mesocycle_payload()],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLMesocycleRepository(client=client)
+    items, pagination = await repository.list(page=1, page_size=20, status="PLANNED")
+
+    assert len(items) == 1
+    assert items[0].name == "Hypertrophy Block"
+    assert items[0].start_date == "2026-01-01"
+    assert pagination == {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1}
+    client.execute.assert_awaited_once_with(
+        LIST_MESOCYCLES,
+        {"pagination": {"page": 1, "pageSize": 20}, "status": "PLANNED"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_get_maps_mesocycle() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"mesocycle": _mesocycle_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    mesocycle = await repository.get("11111111-1111-1111-1111-111111111111")
+
+    assert mesocycle.id == "11111111-1111-1111-1111-111111111111"
+    client.execute.assert_awaited_once_with(
+        GET_MESOCYCLE,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_create_maps_mesocycle() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"createMesocycle": _mesocycle_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    mesocycle = await repository.create({"name": "Hypertrophy Block", "startDate": "2026-01-01"})
+
+    assert mesocycle.name == "Hypertrophy Block"
+    client.execute.assert_awaited_once_with(
+        CREATE_MESOCYCLE,
+        {"input": {"name": "Hypertrophy Block", "startDate": "2026-01-01"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_maps_mesocycle() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updateMesocycle": _mesocycle_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    mesocycle = await repository.update(
+        "11111111-1111-1111-1111-111111111111",
+        {"status": "ACTIVE"},
+    )
+
+    assert mesocycle.status == "PLANNED"
+    client.execute.assert_awaited_once_with(
+        UPDATE_MESOCYCLE,
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "input": {"status": "ACTIVE"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_delete_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"deleteMesocycle": True})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    deleted = await repository.delete("11111111-1111-1111-1111-111111111111")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        DELETE_MESOCYCLE,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )

--- a/cli/tests/unit/test_mesocycle_service.py
+++ b/cli/tests/unit/test_mesocycle_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.dto.mesocycle import CreateMesocycleInputDTO, UpdateMesocycleInputDTO
+from workouter_cli.application.services.mesocycle_service import MesocycleService
+from workouter_cli.domain.entities.mesocycle import Mesocycle
+
+
+def _mesocycle() -> Mesocycle:
+    return Mesocycle(
+        id="11111111-1111-1111-1111-111111111111",
+        name="Hypertrophy Block",
+        description="Upper focus",
+        start_date="2026-01-01",
+        end_date=None,
+        status="PLANNED",
+        weeks=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.list = AsyncMock(
+        return_value=([_mesocycle()], {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1})
+    )
+    repository.get = AsyncMock(return_value=_mesocycle())
+    repository.create = AsyncMock(return_value=_mesocycle())
+    repository.update = AsyncMock(return_value=_mesocycle())
+    repository.delete = AsyncMock(return_value=True)
+
+    service = MesocycleService(mesocycle_repository=repository)
+
+    items, pagination = await service.list(page=1, page_size=20, status="PLANNED")
+    fetched = await service.get("11111111-1111-1111-1111-111111111111")
+    created = await service.create(
+        CreateMesocycleInputDTO(
+            name="Hypertrophy Block",
+            start_date=date(2026, 1, 1),
+        )
+    )
+    updated = await service.update(
+        "11111111-1111-1111-1111-111111111111",
+        UpdateMesocycleInputDTO(status="ACTIVE"),
+    )
+    deleted = await service.delete("11111111-1111-1111-1111-111111111111")
+
+    assert len(items) == 1
+    assert pagination["total"] == 1
+    assert fetched.name == "Hypertrophy Block"
+    assert created.status == "PLANNED"
+    assert updated.id == "11111111-1111-1111-1111-111111111111"
+    assert deleted is True
+
+    repository.list.assert_awaited_once_with(page=1, page_size=20, status="PLANNED")
+    repository.get.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+    repository.create.assert_awaited_once_with(
+        {"name": "Hypertrophy Block", "startDate": "2026-01-01"}
+    )
+    repository.update.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111",
+        {"status": "ACTIVE"},
+    )
+    repository.delete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")


### PR DESCRIPTION
## Summary
- add complete mesocycles CRUD vertical slice across domain, DTOs, services, GraphQL queries/mutations, repository, and CLI wiring
- implement `mesocycles` command group with `list/get/create/update/delete`, pagination/status filters, dry-run support, and local validation for update/delete flows
- add unit and integration coverage for mesocycle repository/service/commands plus help/schema assertions for discoverability

## Validation
- uv run pytest
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src

Closes #19