### PR TITLE
[CLI][Mesocycles] Implement mesocycle planning commands

### DIFF
--- a/cli/src/workouter_cli/application/dto/__init__.py
+++ b/cli/src/workouter_cli/application/dto/__init__.py
@@ -1,7 +1,14 @@
 """Application DTO package."""
 
 from workouter_cli.application.dto.exercise import CreateExerciseInputDTO, UpdateExerciseInputDTO
-from workouter_cli.application.dto.mesocycle import CreateMesocycleInputDTO, UpdateMesocycleInputDTO
+from workouter_cli.application.dto.mesocycle import (
+    AddMesocycleWeekInputDTO,
+    AddPlannedSessionInputDTO,
+    CreateMesocycleInputDTO,
+    UpdateMesocycleInputDTO,
+    UpdateMesocycleWeekInputDTO,
+    UpdatePlannedSessionInputDTO,
+)
 from workouter_cli.application.dto.pagination import PaginationInput, PaginationResult
 from workouter_cli.application.dto.routine import CreateRoutineInputDTO, UpdateRoutineInputDTO
 
@@ -10,6 +17,10 @@ __all__ = [
     "UpdateExerciseInputDTO",
     "CreateMesocycleInputDTO",
     "UpdateMesocycleInputDTO",
+    "AddMesocycleWeekInputDTO",
+    "UpdateMesocycleWeekInputDTO",
+    "AddPlannedSessionInputDTO",
+    "UpdatePlannedSessionInputDTO",
     "CreateRoutineInputDTO",
     "UpdateRoutineInputDTO",
     "PaginationInput",

--- a/cli/src/workouter_cli/application/dto/mesocycle.py
+++ b/cli/src/workouter_cli/application/dto/mesocycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date as dt_date
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -14,7 +14,7 @@ class CreateMesocycleInputDTO(BaseModel):
 
     name: str = Field(min_length=1, max_length=200)
     description: str | None = None
-    start_date: date = Field(alias="startDate")
+    start_date: dt_date = Field(alias="startDate")
 
     @field_validator("name")
     @classmethod
@@ -32,8 +32,8 @@ class UpdateMesocycleInputDTO(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = None
-    start_date: date | None = Field(default=None, alias="startDate")
-    end_date: date | None = Field(default=None, alias="endDate")
+    start_date: dt_date | None = Field(default=None, alias="startDate")
+    end_date: dt_date | None = Field(default=None, alias="endDate")
     status: str | None = None
 
     @field_validator("name")
@@ -54,3 +54,67 @@ class UpdateMesocycleInputDTO(BaseModel):
             msg = "Mesocycle status must be one of: PLANNED, ACTIVE, COMPLETED"
             raise ValueError(msg)
         return value
+
+
+class AddMesocycleWeekInputDTO(BaseModel):
+    """Validated payload for adding a mesocycle week."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    week_number: int = Field(alias="weekNumber", ge=1)
+    week_type: str = Field(alias="weekType")
+    start_date: dt_date = Field(alias="startDate")
+    end_date: dt_date = Field(alias="endDate")
+
+    @field_validator("week_type")
+    @classmethod
+    def validate_week_type(cls, value: str) -> str:
+        allowed = {"TRAINING", "DELOAD"}
+        if value not in allowed:
+            msg = "Week type must be one of: TRAINING, DELOAD"
+            raise ValueError(msg)
+        return value
+
+
+class UpdateMesocycleWeekInputDTO(BaseModel):
+    """Validated payload for updating a mesocycle week."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    week_number: int | None = Field(default=None, alias="weekNumber", ge=1)
+    week_type: str | None = Field(default=None, alias="weekType")
+    start_date: dt_date | None = Field(default=None, alias="startDate")
+    end_date: dt_date | None = Field(default=None, alias="endDate")
+
+    @field_validator("week_type")
+    @classmethod
+    def validate_optional_week_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        allowed = {"TRAINING", "DELOAD"}
+        if value not in allowed:
+            msg = "Week type must be one of: TRAINING, DELOAD"
+            raise ValueError(msg)
+        return value
+
+
+class AddPlannedSessionInputDTO(BaseModel):
+    """Validated payload for adding a planned session."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    routine_id: str | None = Field(default=None, alias="routineId")
+    day_of_week: int = Field(alias="dayOfWeek", ge=1, le=7)
+    date: dt_date | None = None
+    notes: str | None = None
+
+
+class UpdatePlannedSessionInputDTO(BaseModel):
+    """Validated payload for updating a planned session."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, populate_by_name=True)
+
+    routine_id: str | None = Field(default=None, alias="routineId")
+    day_of_week: int | None = Field(default=None, alias="dayOfWeek", ge=1, le=7)
+    date: dt_date | None = None
+    notes: str | None = None

--- a/cli/src/workouter_cli/application/services/mesocycle_service.py
+++ b/cli/src/workouter_cli/application/services/mesocycle_service.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 from workouter_cli.application.dto.mesocycle import (
+    AddMesocycleWeekInputDTO,
+    AddPlannedSessionInputDTO,
     CreateMesocycleInputDTO,
+    UpdateMesocycleWeekInputDTO,
     UpdateMesocycleInputDTO,
+    UpdatePlannedSessionInputDTO,
 )
-from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
 
 
@@ -41,3 +49,35 @@ class MesocycleService:
 
     async def delete(self, mesocycle_id: str) -> bool:
         return await self.mesocycle_repository.delete(mesocycle_id)
+
+    async def add_week(self, mesocycle_id: str, payload: AddMesocycleWeekInputDTO) -> MesocycleWeek:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.add_week(mesocycle_id, data)
+
+    async def update_week(
+        self, week_id: str, payload: UpdateMesocycleWeekInputDTO
+    ) -> MesocycleWeek:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.update_week(week_id, data)
+
+    async def remove_week(self, week_id: str) -> bool:
+        return await self.mesocycle_repository.remove_week(week_id)
+
+    async def add_session(
+        self,
+        mesocycle_week_id: str,
+        payload: AddPlannedSessionInputDTO,
+    ) -> MesocyclePlannedSession:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.add_session(mesocycle_week_id, data)
+
+    async def update_session(
+        self,
+        session_id: str,
+        payload: UpdatePlannedSessionInputDTO,
+    ) -> MesocyclePlannedSession:
+        data = payload.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return await self.mesocycle_repository.update_session(session_id, data)
+
+    async def remove_session(self, session_id: str) -> bool:
+        return await self.mesocycle_repository.remove_session(session_id)

--- a/cli/src/workouter_cli/domain/entities/__init__.py
+++ b/cli/src/workouter_cli/domain/entities/__init__.py
@@ -2,7 +2,11 @@
 
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
-from workouter_cli.domain.entities.mesocycle import Mesocycle, MesocycleWeek
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
@@ -11,6 +15,7 @@ __all__ = [
     "ExerciseMuscleGroup",
     "Exercise",
     "MesocycleWeek",
+    "MesocyclePlannedSession",
     "Mesocycle",
     "RoutineSet",
     "RoutineExercise",

--- a/cli/src/workouter_cli/domain/entities/mesocycle.py
+++ b/cli/src/workouter_cli/domain/entities/mesocycle.py
@@ -6,6 +6,18 @@ from dataclasses import dataclass
 
 
 @dataclass(slots=True, frozen=True)
+class MesocyclePlannedSession:
+    """Planned session details nested under a mesocycle week."""
+
+    id: str
+    routine_id: str | None
+    routine_name: str | None
+    day_of_week: int
+    date: str
+    notes: str | None
+
+
+@dataclass(slots=True, frozen=True)
 class MesocycleWeek:
     """Mesocycle week planning details."""
 
@@ -14,6 +26,7 @@ class MesocycleWeek:
     week_type: str
     start_date: str
     end_date: str
+    planned_sessions: tuple[MesocyclePlannedSession, ...]
 
 
 @dataclass(slots=True, frozen=True)

--- a/cli/src/workouter_cli/domain/repositories/mesocycle.py
+++ b/cli/src/workouter_cli/domain/repositories/mesocycle.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 
 
 class MesocycleRepository(Protocol):
@@ -33,4 +37,32 @@ class MesocycleRepository(Protocol):
 
     async def delete(self, mesocycle_id: str) -> bool:
         """Delete one mesocycle."""
+        ...
+
+    async def add_week(self, mesocycle_id: str, payload: dict[str, object]) -> MesocycleWeek:
+        """Add one planning week to a mesocycle."""
+        ...
+
+    async def update_week(self, week_id: str, payload: dict[str, object]) -> MesocycleWeek:
+        """Update one mesocycle planning week."""
+        ...
+
+    async def remove_week(self, week_id: str) -> bool:
+        """Remove one mesocycle planning week."""
+        ...
+
+    async def add_session(
+        self, mesocycle_week_id: str, payload: dict[str, object]
+    ) -> MesocyclePlannedSession:
+        """Add one planned session to a mesocycle week."""
+        ...
+
+    async def update_session(
+        self, session_id: str, payload: dict[str, object]
+    ) -> MesocyclePlannedSession:
+        """Update one mesocycle planned session."""
+        ...
+
+    async def remove_session(self, session_id: str) -> bool:
+        """Remove one mesocycle planned session."""
         ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
-from workouter_cli.domain.entities.mesocycle import Mesocycle, MesocycleWeek
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 from workouter_cli.domain.entities.routine import Routine, RoutineExercise, RoutineSet
 from workouter_cli.domain.entities.session import Session, SessionExercise, SessionSet
 
@@ -162,6 +166,23 @@ def map_mesocycle_week(data: dict[str, Any]) -> MesocycleWeek:
         week_type=str(data["weekType"]),
         start_date=str(data["startDate"]),
         end_date=str(data["endDate"]),
+        planned_sessions=tuple(
+            map_mesocycle_planned_session(item) for item in data.get("plannedSessions", [])
+        ),
+    )
+
+
+def map_mesocycle_planned_session(data: dict[str, Any]) -> MesocyclePlannedSession:
+    """Map GraphQL mesocycle planned session payload to domain entity."""
+
+    routine = data.get("routine")
+    return MesocyclePlannedSession(
+        id=str(data["id"]),
+        routine_id=str(routine["id"]) if routine is not None else None,
+        routine_name=str(routine["name"]) if routine is not None else None,
+        day_of_week=int(data["dayOfWeek"]),
+        date=str(data["date"]),
+        notes=str(data["notes"]) if data.get("notes") is not None else None,
     )
 
 

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -6,9 +6,15 @@ from workouter_cli.infrastructure.graphql.mutations.exercise import (
     UPDATE_EXERCISE,
 )
 from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    ADD_MESOCYCLE_WEEK,
+    ADD_PLANNED_SESSION,
     CREATE_MESOCYCLE,
     DELETE_MESOCYCLE,
+    REMOVE_MESOCYCLE_WEEK,
+    REMOVE_PLANNED_SESSION,
     UPDATE_MESOCYCLE,
+    UPDATE_MESOCYCLE_WEEK,
+    UPDATE_PLANNED_SESSION,
 )
 from workouter_cli.infrastructure.graphql.mutations.routine import (
     ADD_ROUTINE_EXERCISE,
@@ -40,6 +46,12 @@ __all__ = [
     "CREATE_MESOCYCLE",
     "UPDATE_MESOCYCLE",
     "DELETE_MESOCYCLE",
+    "ADD_MESOCYCLE_WEEK",
+    "UPDATE_MESOCYCLE_WEEK",
+    "REMOVE_MESOCYCLE_WEEK",
+    "ADD_PLANNED_SESSION",
+    "UPDATE_PLANNED_SESSION",
+    "REMOVE_PLANNED_SESSION",
     "ADD_ROUTINE_EXERCISE",
     "UPDATE_ROUTINE_EXERCISE",
     "REMOVE_ROUTINE_EXERCISE",

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/mesocycle.py
@@ -2,6 +2,35 @@
 
 from workouter_cli.infrastructure.graphql.queries.mesocycle import MESOCYCLE_FIELDS
 
+MESOCYCLE_WEEK_FIELDS = """
+id
+weekNumber
+weekType
+startDate
+endDate
+plannedSessions {
+  id
+  routine {
+    id
+    name
+  }
+  dayOfWeek
+  date
+  notes
+}
+"""
+
+PLANNED_SESSION_FIELDS = """
+id
+routine {
+  id
+  name
+}
+dayOfWeek
+date
+notes
+"""
+
 CREATE_MESOCYCLE = (
     """
 mutation CreateMesocycle($input: CreateMesocycleInput!) {
@@ -27,5 +56,67 @@ mutation UpdateMesocycle($id: UUID!, $input: UpdateMesocycleInput!) {
 DELETE_MESOCYCLE = """
 mutation DeleteMesocycle($id: UUID!) {
   deleteMesocycle(id: $id)
+}
+"""
+
+
+ADD_MESOCYCLE_WEEK = (
+    """
+mutation AddMesocycleWeek($mesocycleId: UUID!, $input: AddMesocycleWeekInput!) {
+  addMesocycleWeek(mesocycleId: $mesocycleId, input: $input) {
+    %s
+  }
+}
+"""
+    % MESOCYCLE_WEEK_FIELDS
+)
+
+
+UPDATE_MESOCYCLE_WEEK = (
+    """
+mutation UpdateMesocycleWeek($id: UUID!, $input: UpdateMesocycleWeekInput!) {
+  updateMesocycleWeek(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % MESOCYCLE_WEEK_FIELDS
+)
+
+
+REMOVE_MESOCYCLE_WEEK = """
+mutation RemoveMesocycleWeek($id: UUID!) {
+  removeMesocycleWeek(id: $id)
+}
+"""
+
+
+ADD_PLANNED_SESSION = (
+    """
+mutation AddPlannedSession($mesocycleWeekId: UUID!, $input: AddPlannedSessionInput!) {
+  addPlannedSession(mesocycleWeekId: $mesocycleWeekId, input: $input) {
+    %s
+  }
+}
+"""
+    % PLANNED_SESSION_FIELDS
+)
+
+
+UPDATE_PLANNED_SESSION = (
+    """
+mutation UpdatePlannedSession($id: UUID!, $input: UpdatePlannedSessionInput!) {
+  updatePlannedSession(id: $id, input: $input) {
+    %s
+  }
+}
+"""
+    % PLANNED_SESSION_FIELDS
+)
+
+
+REMOVE_PLANNED_SESSION = """
+mutation RemovePlannedSession($id: UUID!) {
+  removePlannedSession(id: $id)
 }
 """

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/mesocycle.py
@@ -13,6 +13,16 @@ weeks {
   weekType
   startDate
   endDate
+  plannedSessions {
+    id
+    routine {
+      id
+      name
+    }
+    dayOfWeek
+    date
+    notes
+  }
 }
 """
 

--- a/cli/src/workouter_cli/infrastructure/repositories/mesocycle.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/mesocycle.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
-from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
-from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_mesocycle
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import (
+    map_mesocycle,
+    map_mesocycle_planned_session,
+    map_mesocycle_week,
+)
 from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    ADD_MESOCYCLE_WEEK,
+    ADD_PLANNED_SESSION,
     CREATE_MESOCYCLE,
     DELETE_MESOCYCLE,
+    REMOVE_MESOCYCLE_WEEK,
+    REMOVE_PLANNED_SESSION,
     UPDATE_MESOCYCLE,
+    UPDATE_MESOCYCLE_WEEK,
+    UPDATE_PLANNED_SESSION,
 )
 from workouter_cli.infrastructure.graphql.queries.mesocycle import (
     GET_MESOCYCLE,
@@ -67,3 +81,59 @@ class GraphQLMesocycleRepository(MesocycleRepository):
     async def delete(self, mesocycle_id: str) -> bool:
         result = await self.client.execute(DELETE_MESOCYCLE, {"id": mesocycle_id})
         return bool(result["deleteMesocycle"])
+
+    async def add_week(self, mesocycle_id: str, payload: dict[str, object]) -> MesocycleWeek:
+        result = await self.client.execute(
+            ADD_MESOCYCLE_WEEK,
+            {
+                "mesocycleId": mesocycle_id,
+                "input": payload,
+            },
+        )
+        return map_mesocycle_week(result["addMesocycleWeek"])
+
+    async def update_week(self, week_id: str, payload: dict[str, object]) -> MesocycleWeek:
+        result = await self.client.execute(
+            UPDATE_MESOCYCLE_WEEK,
+            {
+                "id": week_id,
+                "input": payload,
+            },
+        )
+        return map_mesocycle_week(result["updateMesocycleWeek"])
+
+    async def remove_week(self, week_id: str) -> bool:
+        result = await self.client.execute(REMOVE_MESOCYCLE_WEEK, {"id": week_id})
+        return bool(result["removeMesocycleWeek"])
+
+    async def add_session(
+        self,
+        mesocycle_week_id: str,
+        payload: dict[str, object],
+    ) -> MesocyclePlannedSession:
+        result = await self.client.execute(
+            ADD_PLANNED_SESSION,
+            {
+                "mesocycleWeekId": mesocycle_week_id,
+                "input": payload,
+            },
+        )
+        return map_mesocycle_planned_session(result["addPlannedSession"])
+
+    async def update_session(
+        self,
+        session_id: str,
+        payload: dict[str, object],
+    ) -> MesocyclePlannedSession:
+        result = await self.client.execute(
+            UPDATE_PLANNED_SESSION,
+            {
+                "id": session_id,
+                "input": payload,
+            },
+        )
+        return map_mesocycle_planned_session(result["updatePlannedSession"])
+
+    async def remove_session(self, session_id: str) -> bool:
+        result = await self.client.execute(REMOVE_PLANNED_SESSION, {"id": session_id})
+        return bool(result["removePlannedSession"])

--- a/cli/src/workouter_cli/presentation/commands/mesocycles.py
+++ b/cli/src/workouter_cli/presentation/commands/mesocycles.py
@@ -14,11 +14,19 @@ from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console
 
 from workouter_cli.application.dto.mesocycle import (
+    AddMesocycleWeekInputDTO,
+    AddPlannedSessionInputDTO,
     CreateMesocycleInputDTO,
+    UpdateMesocycleWeekInputDTO,
     UpdateMesocycleInputDTO,
+    UpdatePlannedSessionInputDTO,
 )
 from workouter_cli.application.formatters.factory import get_formatter
-from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 from workouter_cli.domain.exceptions import ValidationError
 from workouter_cli.presentation.context import CLIContext
 
@@ -45,6 +53,11 @@ def _mesocycle_to_payload(mesocycle: Mesocycle) -> dict[str, object]:
 
 def _to_date(value: datetime | None) -> date | None:
     return value.date() if value is not None else None
+
+
+def _require_any_update(payload: dict[str, object], message: str) -> None:
+    if not payload:
+        raise ValidationError(message)
 
 
 @click.group(name="mesocycles")
@@ -203,3 +216,249 @@ def delete_mesocycle(ctx: CLIContext, mesocycle_id: UUID, force: bool) -> None:
 
     deleted: bool = _run(ctx.mesocycle_service.delete(str(mesocycle_id)))
     _render(ctx, {"id": str(mesocycle_id), "deleted": deleted}, command="mesocycles delete")
+
+
+@mesocycles.command(name="add-week")
+@click.argument("mesocycle_id", type=click.UUID)
+@click.option("--week-number", type=click.IntRange(min=1), required=True)
+@click.option(
+    "--week-type",
+    type=click.Choice(["TRAINING", "DELOAD"], case_sensitive=True),
+    required=True,
+)
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.option("--end-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_week(
+    ctx: CLIContext,
+    mesocycle_id: UUID,
+    week_number: int,
+    week_type: str,
+    start_date: datetime,
+    end_date: datetime,
+    dry_run: bool,
+) -> None:
+    """Add one planning week to a mesocycle."""
+
+    if end_date.date() < start_date.date():
+        raise ValidationError("--end-date cannot be earlier than --start-date")
+
+    try:
+        dto = AddMesocycleWeekInputDTO(
+            weekNumber=week_number,
+            weekType=week_type,
+            startDate=start_date.date(),
+            endDate=end_date.date(),
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid add-week payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addMesocycleWeek",
+                "mesocycle_id": str(mesocycle_id),
+                "input": payload,
+            },
+            command="mesocycles add-week",
+        )
+        return
+
+    week: MesocycleWeek = _run(ctx.mesocycle_service.add_week(str(mesocycle_id), dto))
+    _render(ctx, asdict(week), command="mesocycles add-week")
+
+
+@mesocycles.command(name="update-week")
+@click.argument("week_id", type=click.UUID)
+@click.option("--week-number", type=click.IntRange(min=1), default=None)
+@click.option(
+    "--week-type",
+    type=click.Choice(["TRAINING", "DELOAD"], case_sensitive=True),
+    default=None,
+)
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--end-date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_week(
+    ctx: CLIContext,
+    week_id: UUID,
+    week_number: int | None,
+    week_type: str | None,
+    start_date: datetime | None,
+    end_date: datetime | None,
+    dry_run: bool,
+) -> None:
+    """Update one mesocycle planning week."""
+
+    if start_date is not None and end_date is not None and end_date.date() < start_date.date():
+        raise ValidationError("--end-date cannot be earlier than --start-date")
+
+    try:
+        dto = UpdateMesocycleWeekInputDTO(
+            weekNumber=week_number,
+            weekType=week_type,
+            startDate=_to_date(start_date),
+            endDate=_to_date(end_date),
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid update-week payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateMesocycleWeek",
+                "id": str(week_id),
+                "input": payload,
+            },
+            command="mesocycles update-week",
+        )
+        return
+
+    week: MesocycleWeek = _run(ctx.mesocycle_service.update_week(str(week_id), dto))
+    _render(ctx, asdict(week), command="mesocycles update-week")
+
+
+@mesocycles.command(name="remove-week")
+@click.argument("week_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_week(ctx: CLIContext, week_id: UUID, force: bool) -> None:
+    """Remove one planning week from a mesocycle."""
+
+    if not force:
+        raise ValidationError("Use --force to remove mesocycle week")
+
+    deleted: bool = _run(ctx.mesocycle_service.remove_week(str(week_id)))
+    _render(ctx, {"id": str(week_id), "deleted": deleted}, command="mesocycles remove-week")
+
+
+@mesocycles.command(name="add-session")
+@click.argument("week_id", type=click.UUID)
+@click.option("--routine-id", type=click.UUID, default=None)
+@click.option("--day-of-week", type=click.IntRange(min=1, max=7), required=True)
+@click.option("--date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def add_session(
+    ctx: CLIContext,
+    week_id: UUID,
+    routine_id: UUID | None,
+    day_of_week: int,
+    date: datetime | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Add one planned session to a mesocycle week."""
+
+    try:
+        dto = AddPlannedSessionInputDTO(
+            routineId=str(routine_id) if routine_id is not None else None,
+            dayOfWeek=day_of_week,
+            date=date.date() if date is not None else None,
+            notes=notes,
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid add-session payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "addPlannedSession",
+                "week_id": str(week_id),
+                "input": payload,
+            },
+            command="mesocycles add-session",
+        )
+        return
+
+    planned_session: MesocyclePlannedSession = _run(
+        ctx.mesocycle_service.add_session(str(week_id), dto)
+    )
+    _render(ctx, asdict(planned_session), command="mesocycles add-session")
+
+
+@mesocycles.command(name="update-session")
+@click.argument("session_id", type=click.UUID)
+@click.option("--routine-id", type=click.UUID, default=None)
+@click.option("--day-of-week", type=click.IntRange(min=1, max=7), default=None)
+@click.option("--date", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_session(
+    ctx: CLIContext,
+    session_id: UUID,
+    routine_id: UUID | None,
+    day_of_week: int | None,
+    date: datetime | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Update one mesocycle planned session."""
+
+    try:
+        dto = UpdatePlannedSessionInputDTO(
+            routineId=str(routine_id) if routine_id is not None else None,
+            dayOfWeek=day_of_week,
+            date=date.date() if date is not None else None,
+            notes=notes,
+        )
+    except PydanticValidationError as error:
+        message = error.errors()[0]["msg"]
+        raise ValidationError(f"Invalid update-session payload: {message}") from error
+
+    payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updatePlannedSession",
+                "id": str(session_id),
+                "input": payload,
+            },
+            command="mesocycles update-session",
+        )
+        return
+
+    planned_session: MesocyclePlannedSession = _run(
+        ctx.mesocycle_service.update_session(str(session_id), dto)
+    )
+    _render(ctx, asdict(planned_session), command="mesocycles update-session")
+
+
+@mesocycles.command(name="remove-session")
+@click.argument("session_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def remove_session(ctx: CLIContext, session_id: UUID, force: bool) -> None:
+    """Remove one planned session from a mesocycle week."""
+
+    if not force:
+        raise ValidationError("Use --force to remove mesocycle planned session")
+
+    deleted: bool = _run(ctx.mesocycle_service.remove_session(str(session_id)))
+    _render(
+        ctx,
+        {"id": str(session_id), "deleted": deleted},
+        command="mesocycles remove-session",
+    )

--- a/cli/tests/integration/test_mesocycle_commands.py
+++ b/cli/tests/integration/test_mesocycle_commands.py
@@ -24,7 +24,27 @@ def _mesocycle_payload() -> dict[str, object]:
         "startDate": "2026-01-01",
         "endDate": None,
         "status": "PLANNED",
-        "weeks": [],
+        "weeks": [
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "weekNumber": 1,
+                "weekType": "TRAINING",
+                "startDate": "2026-01-01",
+                "endDate": "2026-01-07",
+                "plannedSessions": [
+                    {
+                        "id": "33333333-3333-3333-3333-333333333333",
+                        "routine": {
+                            "id": "44444444-4444-4444-4444-444444444444",
+                            "name": "Push A",
+                        },
+                        "dayOfWeek": 1,
+                        "date": "2026-01-01",
+                        "notes": "Heavy compounds",
+                    }
+                ],
+            }
+        ],
     }
 
 
@@ -38,7 +58,42 @@ def _paginated_mesocycles_payload() -> dict[str, object]:
     }
 
 
-def test_mesocycles_crud_commands_and_delete_validation(mocker) -> None:  # type: ignore[no-untyped-def]
+def _week_payload() -> dict[str, object]:
+    return {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "weekNumber": 1,
+        "weekType": "TRAINING",
+        "startDate": "2026-01-01",
+        "endDate": "2026-01-07",
+        "plannedSessions": [
+            {
+                "id": "33333333-3333-3333-3333-333333333333",
+                "routine": {
+                    "id": "44444444-4444-4444-4444-444444444444",
+                    "name": "Push A",
+                },
+                "dayOfWeek": 1,
+                "date": "2026-01-01",
+                "notes": "Heavy compounds",
+            }
+        ],
+    }
+
+
+def _planned_session_payload() -> dict[str, object]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "routine": {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "name": "Push A",
+        },
+        "dayOfWeek": 1,
+        "date": "2026-01-01",
+        "notes": "Heavy compounds",
+    }
+
+
+def test_mesocycles_crud_and_planning_commands(mocker) -> None:  # type: ignore[no-untyped-def]
     calls: list[str] = []
 
     async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
@@ -48,6 +103,24 @@ def test_mesocycles_crud_commands_and_delete_validation(mocker) -> None:  # type
         if "query GetMesocycle" in query:
             calls.append("get")
             return {"mesocycle": _mesocycle_payload()}
+        if "mutation AddMesocycleWeek" in query:
+            calls.append("add-week")
+            return {"addMesocycleWeek": _week_payload()}
+        if "mutation UpdateMesocycleWeek" in query:
+            calls.append("update-week")
+            return {"updateMesocycleWeek": _week_payload()}
+        if "mutation RemoveMesocycleWeek" in query:
+            calls.append("remove-week")
+            return {"removeMesocycleWeek": True}
+        if "mutation AddPlannedSession" in query:
+            calls.append("add-session")
+            return {"addPlannedSession": _planned_session_payload()}
+        if "mutation UpdatePlannedSession" in query:
+            calls.append("update-session")
+            return {"updatePlannedSession": _planned_session_payload()}
+        if "mutation RemovePlannedSession" in query:
+            calls.append("remove-session")
+            return {"removePlannedSession": True}
         if "mutation CreateMesocycle" in query:
             calls.append("create")
             return {"createMesocycle": _mesocycle_payload()}
@@ -159,4 +232,190 @@ def test_mesocycles_crud_commands_and_delete_validation(mocker) -> None:  # type
     )
     assert delete_result.exit_code == 0
 
-    assert calls == ["list", "get", "create", "update", "delete"]
+    add_week_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "add-week",
+            "11111111-1111-1111-1111-111111111111",
+            "--week-number",
+            "1",
+            "--week-type",
+            "TRAINING",
+            "--start-date",
+            "2026-01-01",
+            "--end-date",
+            "2026-01-07",
+            "--dry-run",
+        ],
+    )
+    assert add_week_dry_run.exit_code == 0
+    assert json.loads(add_week_dry_run.output.strip())["data"]["dry_run"] is True
+
+    add_week_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "add-week",
+            "11111111-1111-1111-1111-111111111111",
+            "--week-number",
+            "1",
+            "--week-type",
+            "TRAINING",
+            "--start-date",
+            "2026-01-01",
+            "--end-date",
+            "2026-01-07",
+        ],
+    )
+    assert add_week_result.exit_code == 0
+
+    add_week_date_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "add-week",
+            "11111111-1111-1111-1111-111111111111",
+            "--week-number",
+            "1",
+            "--week-type",
+            "TRAINING",
+            "--start-date",
+            "2026-01-07",
+            "--end-date",
+            "2026-01-01",
+        ],
+    )
+    assert add_week_date_validation.exit_code == 1
+
+    update_week_validation = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "update-week", "22222222-2222-2222-2222-222222222222"],
+    )
+    assert update_week_validation.exit_code == 1
+
+    update_week_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "update-week",
+            "22222222-2222-2222-2222-222222222222",
+            "--week-type",
+            "DELOAD",
+        ],
+    )
+    assert update_week_result.exit_code == 0
+
+    remove_week_validation = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "remove-week", "22222222-2222-2222-2222-222222222222"],
+    )
+    assert remove_week_validation.exit_code == 1
+
+    remove_week_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "remove-week",
+            "22222222-2222-2222-2222-222222222222",
+            "--force",
+        ],
+    )
+    assert remove_week_result.exit_code == 0
+
+    add_session_dry_run = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "add-session",
+            "22222222-2222-2222-2222-222222222222",
+            "--routine-id",
+            "44444444-4444-4444-4444-444444444444",
+            "--day-of-week",
+            "1",
+            "--date",
+            "2026-01-01",
+            "--dry-run",
+        ],
+    )
+    assert add_session_dry_run.exit_code == 0
+    assert json.loads(add_session_dry_run.output.strip())["data"]["dry_run"] is True
+
+    add_session_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "add-session",
+            "22222222-2222-2222-2222-222222222222",
+            "--routine-id",
+            "44444444-4444-4444-4444-444444444444",
+            "--day-of-week",
+            "1",
+            "--date",
+            "2026-01-01",
+        ],
+    )
+    assert add_session_result.exit_code == 0
+
+    update_session_validation = runner.invoke(
+        cli,
+        ["--json", "mesocycles", "update-session", "33333333-3333-3333-3333-333333333333"],
+    )
+    assert update_session_validation.exit_code == 1
+
+    update_session_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "update-session",
+            "33333333-3333-3333-3333-333333333333",
+            "--notes",
+            "Updated note",
+        ],
+    )
+    assert update_session_result.exit_code == 0
+
+    remove_session_validation = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "remove-session",
+            "33333333-3333-3333-3333-333333333333",
+        ],
+    )
+    assert remove_session_validation.exit_code == 1
+
+    remove_session_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "mesocycles",
+            "remove-session",
+            "33333333-3333-3333-3333-333333333333",
+            "--force",
+        ],
+    )
+    assert remove_session_result.exit_code == 0
+
+    assert calls == [
+        "list",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "add-week",
+        "update-week",
+        "remove-week",
+        "add-session",
+        "update-session",
+        "remove-session",
+    ]

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -65,3 +65,33 @@ def test_schema_command_outputs_valid_json_for_mesocycles_list() -> None:
     options = {item["name"] for item in payload["options"]}
     assert "--page" in options
     assert "--status" in options
+
+
+def test_schema_command_outputs_valid_json_for_mesocycles_add_week() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles add-week"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "mesocycles add-week"
+    assert payload["description"] == "Add one planning week to a mesocycle."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--week-number" in options
+    assert "--week-type" in options
+
+
+def test_schema_command_outputs_valid_json_for_mesocycles_add_session() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles add-session"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "mesocycles add-session"
+    assert payload["description"] == "Add one planned session to a mesocycle week."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--day-of-week" in options
+    assert "--routine-id" in options

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -166,3 +166,31 @@ def test_schema_mesocycles_list_outputs_machine_readable_definition() -> None:
     option_names = {option["name"] for option in payload["options"]}
     assert "--page" in option_names
     assert "--status" in option_names
+
+
+def test_schema_mesocycles_add_week_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles add-week"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "mesocycles add-week"
+    assert payload["description"] == "Add one planning week to a mesocycle."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--week-number" in option_names
+    assert "--week-type" in option_names
+
+
+def test_schema_mesocycles_add_session_outputs_machine_readable_definition() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "mesocycles add-session"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["command"] == "mesocycles add-session"
+    assert payload["description"] == "Add one planned session to a mesocycle week."
+
+    option_names = {option["name"] for option in payload["options"]}
+    assert "--day-of-week" in option_names
+    assert "--routine-id" in option_names

--- a/cli/tests/unit/test_mesocycle_repository.py
+++ b/cli/tests/unit/test_mesocycle_repository.py
@@ -5,9 +5,15 @@ from unittest.mock import AsyncMock
 import pytest
 
 from workouter_cli.infrastructure.graphql.mutations.mesocycle import (
+    ADD_MESOCYCLE_WEEK,
+    ADD_PLANNED_SESSION,
     CREATE_MESOCYCLE,
     DELETE_MESOCYCLE,
+    REMOVE_MESOCYCLE_WEEK,
+    REMOVE_PLANNED_SESSION,
     UPDATE_MESOCYCLE,
+    UPDATE_MESOCYCLE_WEEK,
+    UPDATE_PLANNED_SESSION,
 )
 from workouter_cli.infrastructure.graphql.queries.mesocycle import GET_MESOCYCLE, LIST_MESOCYCLES
 from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
@@ -22,6 +28,30 @@ def _mesocycle_payload() -> dict[str, object]:
         "endDate": None,
         "status": "PLANNED",
         "weeks": [],
+    }
+
+
+def _week_payload() -> dict[str, object]:
+    return {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "weekNumber": 1,
+        "weekType": "TRAINING",
+        "startDate": "2026-01-01",
+        "endDate": "2026-01-07",
+        "plannedSessions": [],
+    }
+
+
+def _planned_session_payload() -> dict[str, object]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "routine": {
+            "id": "44444444-4444-4444-4444-444444444444",
+            "name": "Push A",
+        },
+        "dayOfWeek": 1,
+        "date": "2026-01-01",
+        "notes": "Heavy compounds",
     }
 
 
@@ -116,4 +146,136 @@ async def test_repository_delete_maps_boolean() -> None:
     client.execute.assert_awaited_once_with(
         DELETE_MESOCYCLE,
         {"id": "11111111-1111-1111-1111-111111111111"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_add_week_maps_mesocycle_week() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"addMesocycleWeek": _week_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    week = await repository.add_week(
+        "11111111-1111-1111-1111-111111111111",
+        {
+            "weekNumber": 1,
+            "weekType": "TRAINING",
+            "startDate": "2026-01-01",
+            "endDate": "2026-01-07",
+        },
+    )
+
+    assert week.week_number == 1
+    client.execute.assert_awaited_once_with(
+        ADD_MESOCYCLE_WEEK,
+        {
+            "mesocycleId": "11111111-1111-1111-1111-111111111111",
+            "input": {
+                "weekNumber": 1,
+                "weekType": "TRAINING",
+                "startDate": "2026-01-01",
+                "endDate": "2026-01-07",
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_week_maps_mesocycle_week() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updateMesocycleWeek": _week_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    week = await repository.update_week(
+        "22222222-2222-2222-2222-222222222222",
+        {"weekType": "DELOAD"},
+    )
+
+    assert week.id == "22222222-2222-2222-2222-222222222222"
+    client.execute.assert_awaited_once_with(
+        UPDATE_MESOCYCLE_WEEK,
+        {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "input": {"weekType": "DELOAD"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_week_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removeMesocycleWeek": True})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    deleted = await repository.remove_week("22222222-2222-2222-2222-222222222222")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_MESOCYCLE_WEEK,
+        {"id": "22222222-2222-2222-2222-222222222222"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_add_session_maps_planned_session() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"addPlannedSession": _planned_session_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    planned_session = await repository.add_session(
+        "22222222-2222-2222-2222-222222222222",
+        {
+            "routineId": "44444444-4444-4444-4444-444444444444",
+            "dayOfWeek": 1,
+            "date": "2026-01-01",
+        },
+    )
+
+    assert planned_session.routine_name == "Push A"
+    client.execute.assert_awaited_once_with(
+        ADD_PLANNED_SESSION,
+        {
+            "mesocycleWeekId": "22222222-2222-2222-2222-222222222222",
+            "input": {
+                "routineId": "44444444-4444-4444-4444-444444444444",
+                "dayOfWeek": 1,
+                "date": "2026-01-01",
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_session_maps_planned_session() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updatePlannedSession": _planned_session_payload()})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    planned_session = await repository.update_session(
+        "33333333-3333-3333-3333-333333333333",
+        {"notes": "Updated"},
+    )
+
+    assert planned_session.id == "33333333-3333-3333-3333-333333333333"
+    client.execute.assert_awaited_once_with(
+        UPDATE_PLANNED_SESSION,
+        {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "input": {"notes": "Updated"},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_remove_session_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"removePlannedSession": True})
+
+    repository = GraphQLMesocycleRepository(client=client)
+    deleted = await repository.remove_session("33333333-3333-3333-3333-333333333333")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        REMOVE_PLANNED_SESSION,
+        {"id": "33333333-3333-3333-3333-333333333333"},
     )

--- a/cli/tests/unit/test_mesocycle_service.py
+++ b/cli/tests/unit/test_mesocycle_service.py
@@ -5,9 +5,20 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from workouter_cli.application.dto.mesocycle import CreateMesocycleInputDTO, UpdateMesocycleInputDTO
+from workouter_cli.application.dto.mesocycle import (
+    AddMesocycleWeekInputDTO,
+    AddPlannedSessionInputDTO,
+    CreateMesocycleInputDTO,
+    UpdateMesocycleInputDTO,
+    UpdateMesocycleWeekInputDTO,
+    UpdatePlannedSessionInputDTO,
+)
 from workouter_cli.application.services.mesocycle_service import MesocycleService
-from workouter_cli.domain.entities.mesocycle import Mesocycle
+from workouter_cli.domain.entities.mesocycle import (
+    Mesocycle,
+    MesocyclePlannedSession,
+    MesocycleWeek,
+)
 
 
 def _mesocycle() -> Mesocycle:
@@ -22,6 +33,28 @@ def _mesocycle() -> Mesocycle:
     )
 
 
+def _week() -> MesocycleWeek:
+    return MesocycleWeek(
+        id="22222222-2222-2222-2222-222222222222",
+        week_number=1,
+        week_type="TRAINING",
+        start_date="2026-01-01",
+        end_date="2026-01-07",
+        planned_sessions=(),
+    )
+
+
+def _planned_session() -> MesocyclePlannedSession:
+    return MesocyclePlannedSession(
+        id="33333333-3333-3333-3333-333333333333",
+        routine_id="44444444-4444-4444-4444-444444444444",
+        routine_name="Push A",
+        day_of_week=1,
+        date="2026-01-01",
+        notes="Heavy compounds",
+    )
+
+
 @pytest.mark.asyncio
 async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
     repository = mocker.Mock()
@@ -32,6 +65,12 @@ async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore
     repository.create = AsyncMock(return_value=_mesocycle())
     repository.update = AsyncMock(return_value=_mesocycle())
     repository.delete = AsyncMock(return_value=True)
+    repository.add_week = AsyncMock(return_value=_week())
+    repository.update_week = AsyncMock(return_value=_week())
+    repository.remove_week = AsyncMock(return_value=True)
+    repository.add_session = AsyncMock(return_value=_planned_session())
+    repository.update_session = AsyncMock(return_value=_planned_session())
+    repository.remove_session = AsyncMock(return_value=True)
 
     service = MesocycleService(mesocycle_repository=repository)
 
@@ -48,6 +87,33 @@ async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore
         UpdateMesocycleInputDTO(status="ACTIVE"),
     )
     deleted = await service.delete("11111111-1111-1111-1111-111111111111")
+    added_week = await service.add_week(
+        "11111111-1111-1111-1111-111111111111",
+        AddMesocycleWeekInputDTO(
+            weekNumber=1,
+            weekType="TRAINING",
+            startDate=date(2026, 1, 1),
+            endDate=date(2026, 1, 7),
+        ),
+    )
+    updated_week = await service.update_week(
+        "22222222-2222-2222-2222-222222222222",
+        UpdateMesocycleWeekInputDTO(weekType="DELOAD"),
+    )
+    removed_week = await service.remove_week("22222222-2222-2222-2222-222222222222")
+    added_session = await service.add_session(
+        "22222222-2222-2222-2222-222222222222",
+        AddPlannedSessionInputDTO(
+            routineId="44444444-4444-4444-4444-444444444444",
+            dayOfWeek=1,
+            date=date(2026, 1, 1),
+        ),
+    )
+    updated_session = await service.update_session(
+        "33333333-3333-3333-3333-333333333333",
+        UpdatePlannedSessionInputDTO(notes="Updated"),
+    )
+    removed_session = await service.remove_session("33333333-3333-3333-3333-333333333333")
 
     assert len(items) == 1
     assert pagination["total"] == 1
@@ -55,6 +121,12 @@ async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore
     assert created.status == "PLANNED"
     assert updated.id == "11111111-1111-1111-1111-111111111111"
     assert deleted is True
+    assert added_week.week_number == 1
+    assert updated_week.week_type == "TRAINING"
+    assert removed_week is True
+    assert added_session.day_of_week == 1
+    assert updated_session.id == "33333333-3333-3333-3333-333333333333"
+    assert removed_session is True
 
     repository.list.assert_awaited_once_with(page=1, page_size=20, status="PLANNED")
     repository.get.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
@@ -66,3 +138,30 @@ async def test_mesocycle_service_crud_delegates(mocker) -> None:  # type: ignore
         {"status": "ACTIVE"},
     )
     repository.delete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+    repository.add_week.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111",
+        {
+            "weekNumber": 1,
+            "weekType": "TRAINING",
+            "startDate": "2026-01-01",
+            "endDate": "2026-01-07",
+        },
+    )
+    repository.update_week.assert_awaited_once_with(
+        "22222222-2222-2222-2222-222222222222",
+        {"weekType": "DELOAD"},
+    )
+    repository.remove_week.assert_awaited_once_with("22222222-2222-2222-2222-222222222222")
+    repository.add_session.assert_awaited_once_with(
+        "22222222-2222-2222-2222-222222222222",
+        {
+            "routineId": "44444444-4444-4444-4444-444444444444",
+            "dayOfWeek": 1,
+            "date": "2026-01-01",
+        },
+    )
+    repository.update_session.assert_awaited_once_with(
+        "33333333-3333-3333-3333-333333333333",
+        {"notes": "Updated"},
+    )
+    repository.remove_session.assert_awaited_once_with("33333333-3333-3333-3333-333333333333")


### PR DESCRIPTION
## Summary
- Add `mesocycles` planning subcommands: `add-week`, `update-week`, `remove-week`, `add-session`, `update-session`, and `remove-session` with input validation and `--dry-run` behavior.
- Extend mesocycle DTOs, entities, repository/service contracts, GraphQL operations, and response mapping to support week and planned session planning mutations.
- Add/extend integration and unit tests for planning commands plus schema coverage for the new command surfaces.

## Validation
- `uv run ruff check .`
- `uv run pytest`

Closes #20