### PR TITLE
[CLI] Implement bodyweight, insights, calendar, and backup command groups

### DIFF
--- a/cli/src/workouter_cli/application/services/__init__.py
+++ b/cli/src/workouter_cli/application/services/__init__.py
@@ -1,6 +1,9 @@
 """Application services package."""
 
+from workouter_cli.application.services.backup_service import BackupService
+from workouter_cli.application.services.bodyweight_service import BodyweightService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.insight_service import InsightService
 from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.session_service import SessionService
 from workouter_cli.application.services.calendar_service import CalendarService
@@ -8,7 +11,10 @@ from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.workflow_service import WorkflowService
 
 __all__ = [
+    "BackupService",
+    "BodyweightService",
     "ExerciseService",
+    "InsightService",
     "MesocycleService",
     "SessionService",
     "CalendarService",

--- a/cli/src/workouter_cli/application/services/backup_service.py
+++ b/cli/src/workouter_cli/application/services/backup_service.py
@@ -1,0 +1,16 @@
+"""Backup application service."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.backup import BackupResult
+from workouter_cli.domain.repositories.backup import BackupRepository
+
+
+class BackupService:
+    """Backup use-cases orchestration."""
+
+    def __init__(self, backup_repository: BackupRepository) -> None:
+        self.backup_repository = backup_repository
+
+    async def trigger(self) -> BackupResult:
+        return await self.backup_repository.trigger()

--- a/cli/src/workouter_cli/application/services/bodyweight_service.py
+++ b/cli/src/workouter_cli/application/services/bodyweight_service.py
@@ -1,0 +1,40 @@
+"""Bodyweight application service."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
+from workouter_cli.domain.repositories.bodyweight import BodyweightRepository
+
+
+class BodyweightService:
+    """Bodyweight use-cases orchestration."""
+
+    def __init__(self, bodyweight_repository: BodyweightRepository) -> None:
+        self.bodyweight_repository = bodyweight_repository
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> tuple[list[BodyweightLog], dict[str, int]]:
+        return await self.bodyweight_repository.list(
+            page=page,
+            page_size=page_size,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+    async def log(self, payload: dict[str, str | float | None]) -> BodyweightLog:
+        return await self.bodyweight_repository.log(payload)
+
+    async def update(
+        self,
+        bodyweight_log_id: str,
+        payload: dict[str, str | float | None],
+    ) -> BodyweightLog:
+        return await self.bodyweight_repository.update(bodyweight_log_id, payload)
+
+    async def delete(self, bodyweight_log_id: str) -> bool:
+        return await self.bodyweight_repository.delete(bodyweight_log_id)

--- a/cli/src/workouter_cli/application/services/calendar_service.py
+++ b/cli/src/workouter_cli/application/services/calendar_service.py
@@ -14,3 +14,6 @@ class CalendarService:
 
     async def day(self, date: str) -> CalendarDay:
         return await self.calendar_repository.day(date)
+
+    async def range(self, start_date: str, end_date: str) -> list[CalendarDay]:
+        return await self.calendar_repository.range(start_date, end_date)

--- a/cli/src/workouter_cli/application/services/insight_service.py
+++ b/cli/src/workouter_cli/application/services/insight_service.py
@@ -1,0 +1,47 @@
+"""Insights application service."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+)
+from workouter_cli.domain.entities.session import Session
+from workouter_cli.domain.repositories.insight import InsightRepository
+
+
+class InsightService:
+    """Insight use-cases orchestration."""
+
+    def __init__(self, insight_repository: InsightRepository) -> None:
+        self.insight_repository = insight_repository
+
+    async def volume(self, mesocycle_id: str, muscle_group_id: str | None = None) -> VolumeInsight:
+        return await self.insight_repository.volume(
+            mesocycle_id=mesocycle_id,
+            muscle_group_id=muscle_group_id,
+        )
+
+    async def intensity(self, mesocycle_id: str) -> IntensityInsight:
+        return await self.insight_repository.intensity(mesocycle_id=mesocycle_id)
+
+    async def overload(self, mesocycle_id: str, exercise_id: str) -> ProgressiveOverloadInsight:
+        return await self.insight_repository.overload(
+            mesocycle_id=mesocycle_id,
+            exercise_id=exercise_id,
+        )
+
+    async def history(
+        self,
+        exercise_id: str,
+        routine_id: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Session], dict[str, int]]:
+        return await self.insight_repository.history(
+            exercise_id=exercise_id,
+            routine_id=routine_id,
+            page=page,
+            page_size=page_size,
+        )

--- a/cli/src/workouter_cli/domain/entities/__init__.py
+++ b/cli/src/workouter_cli/domain/entities/__init__.py
@@ -1,7 +1,18 @@
 """Domain entities package."""
 
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
+from workouter_cli.domain.entities.backup import BackupResult
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    MuscleGroupVolume,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+    WeeklyExerciseProgress,
+    WeeklyIntensity,
+    WeeklyVolume,
+)
 from workouter_cli.domain.entities.mesocycle import (
     Mesocycle,
     MesocyclePlannedSession,
@@ -25,4 +36,13 @@ __all__ = [
     "Session",
     "PlannedSession",
     "CalendarDay",
+    "BodyweightLog",
+    "WeeklyVolume",
+    "MuscleGroupVolume",
+    "VolumeInsight",
+    "WeeklyIntensity",
+    "IntensityInsight",
+    "WeeklyExerciseProgress",
+    "ProgressiveOverloadInsight",
+    "BackupResult",
 ]

--- a/cli/src/workouter_cli/domain/entities/backup.py
+++ b/cli/src/workouter_cli/domain/entities/backup.py
@@ -1,0 +1,15 @@
+"""Backup domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class BackupResult:
+    """Backup trigger result payload."""
+
+    success: bool
+    filename: str | None
+    size_bytes: int | None
+    created_at: str

--- a/cli/src/workouter_cli/domain/entities/bodyweight.py
+++ b/cli/src/workouter_cli/domain/entities/bodyweight.py
@@ -1,0 +1,16 @@
+"""Bodyweight domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class BodyweightLog:
+    """Single bodyweight measurement log."""
+
+    id: str
+    weight_kg: float
+    recorded_at: str
+    notes: str | None
+    created_at: str

--- a/cli/src/workouter_cli/domain/entities/insight.py
+++ b/cli/src/workouter_cli/domain/entities/insight.py
@@ -1,0 +1,71 @@
+"""Insights domain entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class WeeklyVolume:
+    """Weekly set volume by muscle group."""
+
+    week_number: int
+    muscle_group_id: str
+    muscle_group_name: str
+    set_count: int
+
+
+@dataclass(slots=True, frozen=True)
+class MuscleGroupVolume:
+    """Volume contribution per muscle group."""
+
+    muscle_group_id: str
+    muscle_group_name: str
+    total_sets: int
+
+
+@dataclass(slots=True, frozen=True)
+class VolumeInsight:
+    """Mesocycle volume insight aggregate."""
+
+    mesocycle_id: str
+    weekly_volumes: tuple[WeeklyVolume, ...]
+    total_sets: int
+    muscle_group_breakdown: tuple[MuscleGroupVolume, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class WeeklyIntensity:
+    """Weekly intensity trend."""
+
+    week_number: int
+    avg_rir: float
+
+
+@dataclass(slots=True, frozen=True)
+class IntensityInsight:
+    """Mesocycle intensity insight aggregate."""
+
+    mesocycle_id: str
+    weekly_intensities: tuple[WeeklyIntensity, ...]
+    overall_avg_rir: float
+
+
+@dataclass(slots=True, frozen=True)
+class WeeklyExerciseProgress:
+    """Exercise progression metrics for one week."""
+
+    week_number: int
+    max_weight: float
+    avg_reps: float
+    avg_rir: float
+
+
+@dataclass(slots=True, frozen=True)
+class ProgressiveOverloadInsight:
+    """Progressive overload trend for one exercise in mesocycle."""
+
+    exercise_id: str
+    mesocycle_id: str
+    weekly_progress: tuple[WeeklyExerciseProgress, ...]
+    estimated_one_rep_max_progression: tuple[float, ...]

--- a/cli/src/workouter_cli/domain/repositories/__init__.py
+++ b/cli/src/workouter_cli/domain/repositories/__init__.py
@@ -1,13 +1,19 @@
 """Domain repository protocols package."""
 
+from workouter_cli.domain.repositories.backup import BackupRepository
+from workouter_cli.domain.repositories.bodyweight import BodyweightRepository
 from workouter_cli.domain.repositories.exercise import ExerciseRepository
+from workouter_cli.domain.repositories.insight import InsightRepository
 from workouter_cli.domain.repositories.mesocycle import MesocycleRepository
 from workouter_cli.domain.repositories.session import SessionRepository
 from workouter_cli.domain.repositories.calendar import CalendarRepository
 from workouter_cli.domain.repositories.routine import RoutineRepository
 
 __all__ = [
+    "BackupRepository",
+    "BodyweightRepository",
     "ExerciseRepository",
+    "InsightRepository",
     "MesocycleRepository",
     "SessionRepository",
     "CalendarRepository",

--- a/cli/src/workouter_cli/domain/repositories/backup.py
+++ b/cli/src/workouter_cli/domain/repositories/backup.py
@@ -1,0 +1,15 @@
+"""Backup repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.backup import BackupResult
+
+
+class BackupRepository(Protocol):
+    """Persistence contract for backup operations."""
+
+    async def trigger(self) -> BackupResult:
+        """Trigger one backup operation."""
+        ...

--- a/cli/src/workouter_cli/domain/repositories/bodyweight.py
+++ b/cli/src/workouter_cli/domain/repositories/bodyweight.py
@@ -1,0 +1,37 @@
+"""Bodyweight repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
+
+
+class BodyweightRepository(Protocol):
+    """Persistence contract for bodyweight logs."""
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> tuple[list[BodyweightLog], dict[str, int]]:
+        """List bodyweight logs and return items with pagination metadata."""
+        ...
+
+    async def log(self, payload: dict[str, str | float | None]) -> BodyweightLog:
+        """Create one bodyweight log entry."""
+        ...
+
+    async def update(
+        self,
+        bodyweight_log_id: str,
+        payload: dict[str, str | float | None],
+    ) -> BodyweightLog:
+        """Update one bodyweight log entry."""
+        ...
+
+    async def delete(self, bodyweight_log_id: str) -> bool:
+        """Delete one bodyweight log entry."""
+        ...

--- a/cli/src/workouter_cli/domain/repositories/calendar.py
+++ b/cli/src/workouter_cli/domain/repositories/calendar.py
@@ -13,3 +13,7 @@ class CalendarRepository(Protocol):
     async def day(self, date: str) -> CalendarDay:
         """Get a single calendar day by date."""
         ...
+
+    async def range(self, start_date: str, end_date: str) -> list[CalendarDay]:
+        """Get a calendar date range."""
+        ...

--- a/cli/src/workouter_cli/domain/repositories/insight.py
+++ b/cli/src/workouter_cli/domain/repositories/insight.py
@@ -1,0 +1,38 @@
+"""Insights repository protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+)
+from workouter_cli.domain.entities.session import Session
+
+
+class InsightRepository(Protocol):
+    """Persistence contract for analytical insight queries."""
+
+    async def volume(self, mesocycle_id: str, muscle_group_id: str | None = None) -> VolumeInsight:
+        """Get mesocycle volume insight."""
+        ...
+
+    async def intensity(self, mesocycle_id: str) -> IntensityInsight:
+        """Get mesocycle intensity insight."""
+        ...
+
+    async def overload(self, mesocycle_id: str, exercise_id: str) -> ProgressiveOverloadInsight:
+        """Get progressive overload insight for one exercise."""
+        ...
+
+    async def history(
+        self,
+        exercise_id: str,
+        routine_id: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Session], dict[str, int]]:
+        """Get exercise history sessions and pagination metadata."""
+        ...

--- a/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mappers/response_mapper.py
@@ -4,7 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from workouter_cli.domain.entities.backup import BackupResult
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
 from workouter_cli.domain.entities.exercise import Exercise, ExerciseMuscleGroup, MuscleGroup
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    MuscleGroupVolume,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+    WeeklyExerciseProgress,
+    WeeklyIntensity,
+    WeeklyVolume,
+)
 from workouter_cli.domain.entities.calendar import CalendarDay, PlannedSession
 from workouter_cli.domain.entities.mesocycle import (
     Mesocycle,
@@ -230,4 +241,108 @@ def map_calendar_day(data: dict[str, Any]) -> CalendarDay:
         session_id=session_id,
         is_completed=bool(data["isCompleted"]),
         is_rest_day=bool(data["isRestDay"]),
+    )
+
+
+def map_bodyweight_log(data: dict[str, Any]) -> BodyweightLog:
+    """Map GraphQL bodyweight log payload to domain entity."""
+
+    return BodyweightLog(
+        id=str(data["id"]),
+        weight_kg=float(data["weightKg"]),
+        recorded_at=str(data["recordedAt"]),
+        notes=str(data["notes"]) if data.get("notes") is not None else None,
+        created_at=str(data["createdAt"]),
+    )
+
+
+def map_weekly_volume(data: dict[str, Any]) -> WeeklyVolume:
+    """Map weekly volume payload."""
+
+    return WeeklyVolume(
+        week_number=int(data["weekNumber"]),
+        muscle_group_id=str(data["muscleGroupId"]),
+        muscle_group_name=str(data["muscleGroupName"]),
+        set_count=int(data["setCount"]),
+    )
+
+
+def map_muscle_group_volume(data: dict[str, Any]) -> MuscleGroupVolume:
+    """Map muscle group volume payload."""
+
+    return MuscleGroupVolume(
+        muscle_group_id=str(data["muscleGroupId"]),
+        muscle_group_name=str(data["muscleGroupName"]),
+        total_sets=int(data["totalSets"]),
+    )
+
+
+def map_volume_insight(data: dict[str, Any]) -> VolumeInsight:
+    """Map volume insight payload."""
+
+    return VolumeInsight(
+        mesocycle_id=str(data["mesocycleId"]),
+        weekly_volumes=tuple(map_weekly_volume(item) for item in data.get("weeklyVolumes", [])),
+        total_sets=int(data["totalSets"]),
+        muscle_group_breakdown=tuple(
+            map_muscle_group_volume(item) for item in data.get("muscleGroupBreakdown", [])
+        ),
+    )
+
+
+def map_weekly_intensity(data: dict[str, Any]) -> WeeklyIntensity:
+    """Map weekly intensity payload."""
+
+    return WeeklyIntensity(
+        week_number=int(data["weekNumber"]),
+        avg_rir=float(data["avgRir"]),
+    )
+
+
+def map_intensity_insight(data: dict[str, Any]) -> IntensityInsight:
+    """Map intensity insight payload."""
+
+    return IntensityInsight(
+        mesocycle_id=str(data["mesocycleId"]),
+        weekly_intensities=tuple(
+            map_weekly_intensity(item) for item in data.get("weeklyIntensities", [])
+        ),
+        overall_avg_rir=float(data["overallAvgRir"]),
+    )
+
+
+def map_weekly_exercise_progress(data: dict[str, Any]) -> WeeklyExerciseProgress:
+    """Map weekly exercise progress payload."""
+
+    return WeeklyExerciseProgress(
+        week_number=int(data["weekNumber"]),
+        max_weight=float(data["maxWeight"]),
+        avg_reps=float(data["avgReps"]),
+        avg_rir=float(data["avgRir"]),
+    )
+
+
+def map_progressive_overload_insight(data: dict[str, Any]) -> ProgressiveOverloadInsight:
+    """Map progressive overload insight payload."""
+
+    return ProgressiveOverloadInsight(
+        exercise_id=str(data["exerciseId"]),
+        mesocycle_id=str(data["mesocycleId"]),
+        weekly_progress=tuple(
+            map_weekly_exercise_progress(item) for item in data.get("weeklyProgress", [])
+        ),
+        estimated_one_rep_max_progression=tuple(
+            float(item) for item in data.get("estimatedOneRepMaxProgression", [])
+        ),
+    )
+
+
+def map_backup_result(data: dict[str, Any]) -> BackupResult:
+    """Map backup result payload."""
+
+    return BackupResult(
+        success=bool(data["success"]),
+        filename=str(data["filename"]) if data.get("filename") is not None else None,
+        size_bytes=int(data["sizeBytes"]) if data.get("sizeBytes") is not None else None,
+        created_at=str(data["createdAt"]),
     )

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/__init__.py
@@ -1,5 +1,11 @@
 """GraphQL mutations package."""
 
+from workouter_cli.infrastructure.graphql.mutations.backup import TRIGGER_BACKUP
+from workouter_cli.infrastructure.graphql.mutations.bodyweight import (
+    DELETE_BODYWEIGHT_LOG,
+    LOG_BODYWEIGHT,
+    UPDATE_BODYWEIGHT_LOG,
+)
 from workouter_cli.infrastructure.graphql.mutations.exercise import (
     CREATE_EXERCISE,
     DELETE_EXERCISE,
@@ -40,6 +46,10 @@ from workouter_cli.infrastructure.graphql.mutations.session import (
 )
 
 __all__ = [
+    "TRIGGER_BACKUP",
+    "LOG_BODYWEIGHT",
+    "UPDATE_BODYWEIGHT_LOG",
+    "DELETE_BODYWEIGHT_LOG",
     "CREATE_EXERCISE",
     "UPDATE_EXERCISE",
     "DELETE_EXERCISE",

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/backup.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/backup.py
@@ -1,0 +1,12 @@
+"""Backup GraphQL mutations."""
+
+TRIGGER_BACKUP = """
+mutation TriggerBackup {
+  triggerBackup {
+    success
+    filename
+    sizeBytes
+    createdAt
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/mutations/bodyweight.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/mutations/bodyweight.py
@@ -1,0 +1,33 @@
+"""Bodyweight GraphQL mutations."""
+
+LOG_BODYWEIGHT = """
+mutation LogBodyweight($input: LogBodyweightInput!) {
+  logBodyweight(input: $input) {
+    id
+    weightKg
+    recordedAt
+    notes
+    createdAt
+  }
+}
+"""
+
+
+UPDATE_BODYWEIGHT_LOG = """
+mutation UpdateBodyweightLog($id: UUID!, $input: UpdateBodyweightInput!) {
+  updateBodyweightLog(id: $id, input: $input) {
+    id
+    weightKg
+    recordedAt
+    notes
+    createdAt
+  }
+}
+"""
+
+
+DELETE_BODYWEIGHT_LOG = """
+mutation DeleteBodyweightLog($id: UUID!) {
+  deleteBodyweightLog(id: $id)
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/__init__.py
@@ -1,15 +1,28 @@
 """GraphQL queries package."""
 
+from workouter_cli.infrastructure.graphql.queries.bodyweight import LIST_BODYWEIGHT_LOGS
 from workouter_cli.infrastructure.graphql.queries.exercise import GET_EXERCISE, LIST_EXERCISES
-from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
+from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY, CALENDAR_RANGE
+from workouter_cli.infrastructure.graphql.queries.insight import (
+    EXERCISE_HISTORY,
+    MESOCYCLE_INTENSITY_INSIGHT,
+    MESOCYCLE_VOLUME_INSIGHT,
+    PROGRESSIVE_OVERLOAD_INSIGHT,
+)
 from workouter_cli.infrastructure.graphql.queries.mesocycle import GET_MESOCYCLE, LIST_MESOCYCLES
 from workouter_cli.infrastructure.graphql.queries.routine import ROUTINE_FIELDS
 from workouter_cli.infrastructure.graphql.queries.session import GET_SESSION, LIST_SESSIONS
 
 __all__ = [
+    "LIST_BODYWEIGHT_LOGS",
     "GET_EXERCISE",
     "LIST_EXERCISES",
     "CALENDAR_DAY",
+    "CALENDAR_RANGE",
+    "MESOCYCLE_VOLUME_INSIGHT",
+    "MESOCYCLE_INTENSITY_INSIGHT",
+    "PROGRESSIVE_OVERLOAD_INSIGHT",
+    "EXERCISE_HISTORY",
     "LIST_MESOCYCLES",
     "GET_MESOCYCLE",
     "ROUTINE_FIELDS",

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/bodyweight.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/bodyweight.py
@@ -1,0 +1,19 @@
+"""Bodyweight GraphQL queries."""
+
+LIST_BODYWEIGHT_LOGS = """
+query ListBodyweightLogs($pagination: PaginationInput, $dateFrom: DateTime, $dateTo: DateTime) {
+  bodyweightLogs(pagination: $pagination, dateFrom: $dateFrom, dateTo: $dateTo) {
+    items {
+      id
+      weightKg
+      recordedAt
+      notes
+      createdAt
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/calendar.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/calendar.py
@@ -22,3 +22,27 @@ query CalendarDay($date: Date!) {
   }
 }
 """
+
+
+CALENDAR_RANGE = """
+query CalendarRange($startDate: Date!, $endDate: Date!) {
+  calendarRange(startDate: $startDate, endDate: $endDate) {
+    date
+    plannedSession {
+      id
+      routine {
+        id
+        name
+      }
+      dayOfWeek
+      date
+      notes
+    }
+    session {
+      id
+    }
+    isCompleted
+    isRestDay
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/graphql/queries/insight.py
+++ b/cli/src/workouter_cli/infrastructure/graphql/queries/insight.py
@@ -1,0 +1,96 @@
+"""Insights GraphQL queries."""
+
+MESOCYCLE_VOLUME_INSIGHT = """
+query MesocycleVolumeInsight($mesocycleId: UUID!, $muscleGroupId: UUID) {
+  mesocycleVolumeInsight(mesocycleId: $mesocycleId, muscleGroupId: $muscleGroupId) {
+    mesocycleId
+    weeklyVolumes {
+      weekNumber
+      muscleGroupId
+      muscleGroupName
+      setCount
+    }
+    totalSets
+    muscleGroupBreakdown {
+      muscleGroupId
+      muscleGroupName
+      totalSets
+    }
+  }
+}
+"""
+
+MESOCYCLE_INTENSITY_INSIGHT = """
+query MesocycleIntensityInsight($mesocycleId: UUID!) {
+  mesocycleIntensityInsight(mesocycleId: $mesocycleId) {
+    mesocycleId
+    weeklyIntensities {
+      weekNumber
+      avgRir
+    }
+    overallAvgRir
+  }
+}
+"""
+
+PROGRESSIVE_OVERLOAD_INSIGHT = """
+query ProgressiveOverloadInsight($mesocycleId: UUID!, $exerciseId: UUID!) {
+  progressiveOverloadInsight(mesocycleId: $mesocycleId, exerciseId: $exerciseId) {
+    exerciseId
+    mesocycleId
+    weeklyProgress {
+      weekNumber
+      maxWeight
+      avgReps
+      avgRir
+    }
+    estimatedOneRepMaxProgression
+  }
+}
+"""
+
+EXERCISE_HISTORY = """
+query ExerciseHistory($exerciseId: UUID!, $routineId: UUID, $pagination: PaginationInput) {
+  exerciseHistory(exerciseId: $exerciseId, routineId: $routineId, pagination: $pagination) {
+    items {
+      id
+      plannedSessionId
+      mesocycleId
+      routineId
+      status
+      startedAt
+      completedAt
+      notes
+      exercises {
+        id
+        exercise {
+          id
+          name
+        }
+        order
+        supersetGroup
+        restSeconds
+        notes
+        sets {
+          id
+          setNumber
+          setType
+          targetReps
+          targetRir
+          targetWeightKg
+          actualReps
+          actualRir
+          actualWeightKg
+          weightReductionPct
+          restSeconds
+          performedAt
+        }
+      }
+    }
+    total
+    page
+    pageSize
+    totalPages
+  }
+}
+"""

--- a/cli/src/workouter_cli/infrastructure/repositories/__init__.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/__init__.py
@@ -1,13 +1,19 @@
 """Infrastructure repository implementations package."""
 
+from workouter_cli.infrastructure.repositories.backup import GraphQLBackupRepository
+from workouter_cli.infrastructure.repositories.bodyweight import GraphQLBodyweightRepository
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.infrastructure.repositories.insight import GraphQLInsightRepository
 from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
 from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 
 __all__ = [
+    "GraphQLBackupRepository",
+    "GraphQLBodyweightRepository",
     "GraphQLExerciseRepository",
+    "GraphQLInsightRepository",
     "GraphQLMesocycleRepository",
     "GraphQLSessionRepository",
     "GraphQLCalendarRepository",

--- a/cli/src/workouter_cli/infrastructure/repositories/backup.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/backup.py
@@ -1,0 +1,20 @@
+"""GraphQL-backed backup repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.backup import BackupResult
+from workouter_cli.domain.repositories.backup import BackupRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_backup_result
+from workouter_cli.infrastructure.graphql.mutations.backup import TRIGGER_BACKUP
+
+
+class GraphQLBackupRepository(BackupRepository):
+    """Backup repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def trigger(self) -> BackupResult:
+        result = await self.client.execute(TRIGGER_BACKUP, {})
+        return map_backup_result(result["triggerBackup"])

--- a/cli/src/workouter_cli/infrastructure/repositories/bodyweight.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/bodyweight.py
@@ -1,0 +1,63 @@
+"""GraphQL-backed bodyweight repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
+from workouter_cli.domain.repositories.bodyweight import BodyweightRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_bodyweight_log
+from workouter_cli.infrastructure.graphql.mutations.bodyweight import (
+    DELETE_BODYWEIGHT_LOG,
+    LOG_BODYWEIGHT,
+    UPDATE_BODYWEIGHT_LOG,
+)
+from workouter_cli.infrastructure.graphql.queries.bodyweight import LIST_BODYWEIGHT_LOGS
+
+
+class GraphQLBodyweightRepository(BodyweightRepository):
+    """Bodyweight repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> tuple[list[BodyweightLog], dict[str, int]]:
+        variables = {
+            "pagination": {"page": page, "pageSize": page_size},
+            "dateFrom": date_from,
+            "dateTo": date_to,
+        }
+        result = await self.client.execute(LIST_BODYWEIGHT_LOGS, variables)
+        payload = result["bodyweightLogs"]
+        items = [map_bodyweight_log(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination
+
+    async def log(self, payload: dict[str, str | float | None]) -> BodyweightLog:
+        result = await self.client.execute(LOG_BODYWEIGHT, {"input": payload})
+        return map_bodyweight_log(result["logBodyweight"])
+
+    async def update(
+        self,
+        bodyweight_log_id: str,
+        payload: dict[str, str | float | None],
+    ) -> BodyweightLog:
+        result = await self.client.execute(
+            UPDATE_BODYWEIGHT_LOG,
+            {"id": bodyweight_log_id, "input": payload},
+        )
+        return map_bodyweight_log(result["updateBodyweightLog"])
+
+    async def delete(self, bodyweight_log_id: str) -> bool:
+        result = await self.client.execute(DELETE_BODYWEIGHT_LOG, {"id": bodyweight_log_id})
+        return bool(result["deleteBodyweightLog"])

--- a/cli/src/workouter_cli/infrastructure/repositories/calendar.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/calendar.py
@@ -6,7 +6,7 @@ from workouter_cli.domain.entities.calendar import CalendarDay
 from workouter_cli.domain.repositories.calendar import CalendarRepository
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
 from workouter_cli.infrastructure.graphql.mappers.response_mapper import map_calendar_day
-from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY
+from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY, CALENDAR_RANGE
 
 
 class GraphQLCalendarRepository(CalendarRepository):
@@ -18,3 +18,10 @@ class GraphQLCalendarRepository(CalendarRepository):
     async def day(self, date: str) -> CalendarDay:
         result = await self.client.execute(CALENDAR_DAY, {"date": date})
         return map_calendar_day(result["calendarDay"])
+
+    async def range(self, start_date: str, end_date: str) -> list[CalendarDay]:
+        result = await self.client.execute(
+            CALENDAR_RANGE,
+            {"startDate": start_date, "endDate": end_date},
+        )
+        return [map_calendar_day(item) for item in result["calendarRange"]]

--- a/cli/src/workouter_cli/infrastructure/repositories/insight.py
+++ b/cli/src/workouter_cli/infrastructure/repositories/insight.py
@@ -1,0 +1,75 @@
+"""GraphQL-backed insights repository implementation."""
+
+from __future__ import annotations
+
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+)
+from workouter_cli.domain.entities.session import Session
+from workouter_cli.domain.repositories.insight import InsightRepository
+from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.graphql.mappers.response_mapper import (
+    map_intensity_insight,
+    map_progressive_overload_insight,
+    map_session,
+    map_volume_insight,
+)
+from workouter_cli.infrastructure.graphql.queries.insight import (
+    EXERCISE_HISTORY,
+    MESOCYCLE_INTENSITY_INSIGHT,
+    MESOCYCLE_VOLUME_INSIGHT,
+    PROGRESSIVE_OVERLOAD_INSIGHT,
+)
+
+
+class GraphQLInsightRepository(InsightRepository):
+    """Insight repository using GraphQL API operations."""
+
+    def __init__(self, client: GraphQLClient) -> None:
+        self.client = client
+
+    async def volume(self, mesocycle_id: str, muscle_group_id: str | None = None) -> VolumeInsight:
+        result = await self.client.execute(
+            MESOCYCLE_VOLUME_INSIGHT,
+            {"mesocycleId": mesocycle_id, "muscleGroupId": muscle_group_id},
+        )
+        return map_volume_insight(result["mesocycleVolumeInsight"])
+
+    async def intensity(self, mesocycle_id: str) -> IntensityInsight:
+        result = await self.client.execute(
+            MESOCYCLE_INTENSITY_INSIGHT,
+            {"mesocycleId": mesocycle_id},
+        )
+        return map_intensity_insight(result["mesocycleIntensityInsight"])
+
+    async def overload(self, mesocycle_id: str, exercise_id: str) -> ProgressiveOverloadInsight:
+        result = await self.client.execute(
+            PROGRESSIVE_OVERLOAD_INSIGHT,
+            {"mesocycleId": mesocycle_id, "exerciseId": exercise_id},
+        )
+        return map_progressive_overload_insight(result["progressiveOverloadInsight"])
+
+    async def history(
+        self,
+        exercise_id: str,
+        routine_id: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Session], dict[str, int]]:
+        variables = {
+            "exerciseId": exercise_id,
+            "routineId": routine_id,
+            "pagination": {"page": page, "pageSize": page_size},
+        }
+        result = await self.client.execute(EXERCISE_HISTORY, variables)
+        payload = result["exerciseHistory"]
+        items = [map_session(item) for item in payload["items"]]
+        pagination = {
+            "total": int(payload["total"]),
+            "page": int(payload["page"]),
+            "pageSize": int(payload["pageSize"]),
+            "totalPages": int(payload["totalPages"]),
+        }
+        return items, pagination

--- a/cli/src/workouter_cli/main.py
+++ b/cli/src/workouter_cli/main.py
@@ -9,8 +9,11 @@ import click
 from rich.console import Console
 
 from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.application.services.backup_service import BackupService
+from workouter_cli.application.services.bodyweight_service import BodyweightService
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.insight_service import InsightService
 from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
@@ -18,12 +21,19 @@ from workouter_cli.application.services.workflow_service import WorkflowService
 from workouter_cli.domain.exceptions import AuthError, CLIError
 from workouter_cli.infrastructure.config.loader import ConfigError, load_config
 from workouter_cli.infrastructure.graphql.client import GraphQLClient
+from workouter_cli.infrastructure.repositories.backup import GraphQLBackupRepository
+from workouter_cli.infrastructure.repositories.bodyweight import GraphQLBodyweightRepository
 from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
 from workouter_cli.infrastructure.repositories.exercise import GraphQLExerciseRepository
+from workouter_cli.infrastructure.repositories.insight import GraphQLInsightRepository
 from workouter_cli.infrastructure.repositories.mesocycle import GraphQLMesocycleRepository
 from workouter_cli.infrastructure.repositories.routine import GraphQLRoutineRepository
 from workouter_cli.infrastructure.repositories.session import GraphQLSessionRepository
+from workouter_cli.presentation.commands.backup import backup
+from workouter_cli.presentation.commands.bodyweight import bodyweight
+from workouter_cli.presentation.commands.calendar import calendar
 from workouter_cli.presentation.commands.exercises import exercises
+from workouter_cli.presentation.commands.insights import insights
 from workouter_cli.presentation.commands.mesocycles import mesocycles
 from workouter_cli.presentation.commands.routines import routines
 from workouter_cli.presentation.commands.sessions import sessions
@@ -195,11 +205,17 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
         routine_repository = GraphQLRoutineRepository(client=client)
         session_repository = GraphQLSessionRepository(client=client)
         calendar_repository = GraphQLCalendarRepository(client=client)
+        bodyweight_repository = GraphQLBodyweightRepository(client=client)
+        insight_repository = GraphQLInsightRepository(client=client)
+        backup_repository = GraphQLBackupRepository(client=client)
         exercise_service = ExerciseService(exercise_repository=exercise_repository)
         mesocycle_service = MesocycleService(mesocycle_repository=mesocycle_repository)
         routine_service = RoutineService(routine_repository=routine_repository)
         session_service = SessionService(session_repository=session_repository)
         calendar_service = CalendarService(calendar_repository=calendar_repository)
+        bodyweight_service = BodyweightService(bodyweight_repository=bodyweight_repository)
+        insight_service = InsightService(insight_repository=insight_repository)
+        backup_service = BackupService(backup_repository=backup_repository)
         workflow_service = WorkflowService(
             calendar_repository=calendar_repository,
             session_repository=session_repository,
@@ -209,6 +225,9 @@ def cli(ctx: click.Context, output_json: bool, timeout: int | None) -> None:
             client=client,
             output_json=output_json,
             timeout=effective_timeout,
+            backup_service=backup_service,
+            bodyweight_service=bodyweight_service,
+            insight_service=insight_service,
             exercise_service=exercise_service,
             mesocycle_service=mesocycle_service,
             routine_service=routine_service,
@@ -260,4 +279,8 @@ cli.add_command(exercises)
 cli.add_command(mesocycles)
 cli.add_command(routines)
 cli.add_command(sessions)
+cli.add_command(bodyweight)
+cli.add_command(insights)
+cli.add_command(calendar)
+cli.add_command(backup)
 cli.add_command(workout)

--- a/cli/src/workouter_cli/presentation/commands/backup.py
+++ b/cli/src/workouter_cli/presentation/commands/backup.py
@@ -1,0 +1,45 @@
+"""Backup command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import asdict
+from typing import Any, TypeVar
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.backup import BackupResult
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+@click.group(name="backup")
+def backup() -> None:
+    """Backup management commands."""
+
+
+@backup.command(name="trigger")
+@click.pass_obj
+def trigger_backup(ctx: CLIContext) -> None:
+    """Trigger database backup."""
+
+    result: BackupResult = _run(ctx.backup_service.trigger())
+    _render(ctx, asdict(result), command="backup trigger")

--- a/cli/src/workouter_cli/presentation/commands/bodyweight.py
+++ b/cli/src/workouter_cli/presentation/commands/bodyweight.py
@@ -1,0 +1,174 @@
+"""Bodyweight command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine, Mapping
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, TypeVar
+from uuid import UUID
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
+from workouter_cli.domain.exceptions import ValidationError
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+def _require_any_update(payload: Mapping[str, object], message: str) -> None:
+    if not payload:
+        raise ValidationError(message)
+
+
+@click.group(name="bodyweight")
+def bodyweight() -> None:
+    """Bodyweight logging commands."""
+
+
+@bodyweight.command(name="list")
+@click.option("--page", type=int, default=1, show_default=True)
+@click.option("--page-size", type=int, default=20, show_default=True)
+@click.option("--date-from", type=click.DateTime(), default=None)
+@click.option("--date-to", type=click.DateTime(), default=None)
+@click.pass_obj
+def list_bodyweight(
+    ctx: CLIContext,
+    page: int,
+    page_size: int,
+    date_from: datetime | None,
+    date_to: datetime | None,
+) -> None:
+    """List bodyweight logs."""
+
+    items: list[BodyweightLog]
+    pagination: dict[str, int]
+    items, pagination = _run(
+        ctx.bodyweight_service.list(
+            page=page,
+            page_size=page_size,
+            date_from=date_from.isoformat() if date_from is not None else None,
+            date_to=date_to.isoformat() if date_to is not None else None,
+        )
+    )
+    payload = {
+        "items": [asdict(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="bodyweight list")
+
+
+@bodyweight.command(name="log")
+@click.option("--weight", type=float, required=True)
+@click.option("--recorded-at", type=click.DateTime(), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def log_bodyweight(
+    ctx: CLIContext,
+    weight: float,
+    recorded_at: datetime | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Log bodyweight."""
+
+    payload: dict[str, str | float | None] = {
+        "weightKg": weight,
+        "recordedAt": recorded_at.isoformat() if recorded_at is not None else None,
+        "notes": notes,
+    }
+
+    if dry_run:
+        _render(
+            ctx,
+            {"dry_run": True, "operation": "logBodyweight", "input": payload},
+            command="bodyweight log",
+        )
+        return
+
+    created: BodyweightLog = _run(ctx.bodyweight_service.log(payload))
+    _render(ctx, asdict(created), command="bodyweight log")
+
+
+@bodyweight.command(name="update")
+@click.argument("bodyweight_log_id", type=click.UUID)
+@click.option("--weight", type=float, default=None)
+@click.option("--recorded-at", type=click.DateTime(), default=None)
+@click.option("--notes", type=str, default=None)
+@click.option("--dry-run", is_flag=True, help="Validate without mutating")
+@click.pass_obj
+def update_bodyweight(
+    ctx: CLIContext,
+    bodyweight_log_id: UUID,
+    weight: float | None,
+    recorded_at: datetime | None,
+    notes: str | None,
+    dry_run: bool,
+) -> None:
+    """Update one bodyweight log."""
+
+    payload: dict[str, str | float | None] = {}
+    if weight is not None:
+        payload["weightKg"] = weight
+    if recorded_at is not None:
+        payload["recordedAt"] = recorded_at.isoformat()
+    if notes is not None:
+        payload["notes"] = notes
+
+    _require_any_update(payload, "Provide at least one field to update")
+
+    if dry_run:
+        _render(
+            ctx,
+            {
+                "dry_run": True,
+                "operation": "updateBodyweightLog",
+                "id": str(bodyweight_log_id),
+                "input": payload,
+            },
+            command="bodyweight update",
+        )
+        return
+
+    updated: BodyweightLog = _run(ctx.bodyweight_service.update(str(bodyweight_log_id), payload))
+    _render(ctx, asdict(updated), command="bodyweight update")
+
+
+@bodyweight.command(name="delete")
+@click.argument("bodyweight_log_id", type=click.UUID)
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.pass_obj
+def delete_bodyweight(ctx: CLIContext, bodyweight_log_id: UUID, force: bool) -> None:
+    """Delete one bodyweight log."""
+
+    if not force:
+        raise ValidationError("Use --force to delete bodyweight log")
+
+    deleted: bool = _run(ctx.bodyweight_service.delete(str(bodyweight_log_id)))
+    _render(
+        ctx,
+        {"id": str(bodyweight_log_id), "deleted": deleted},
+        command="bodyweight delete",
+    )

--- a/cli/src/workouter_cli/presentation/commands/calendar.py
+++ b/cli/src/workouter_cli/presentation/commands/calendar.py
@@ -1,0 +1,63 @@
+"""Calendar command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any, TypeVar
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.calendar import CalendarDay
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+@click.group(name="calendar")
+def calendar() -> None:
+    """Calendar planning commands."""
+
+
+@calendar.command(name="day")
+@click.option("--date", "date_str", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.pass_obj
+def calendar_day(ctx: CLIContext, date_str: datetime) -> None:
+    """Show one calendar day."""
+
+    day: CalendarDay = _run(ctx.calendar_service.day(date_str.date().isoformat()))
+    _render(ctx, asdict(day), command="calendar day")
+
+
+@calendar.command(name="range")
+@click.option("--start-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.option("--end-date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.pass_obj
+def calendar_range(ctx: CLIContext, start_date: datetime, end_date: datetime) -> None:
+    """Show calendar range."""
+
+    days: list[CalendarDay] = _run(
+        ctx.calendar_service.range(
+            start_date.date().isoformat(),
+            end_date.date().isoformat(),
+        )
+    )
+    _render(ctx, [asdict(day) for day in days], command="calendar range")

--- a/cli/src/workouter_cli/presentation/commands/insights.py
+++ b/cli/src/workouter_cli/presentation/commands/insights.py
@@ -1,0 +1,123 @@
+"""Insights command group."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import asdict
+from typing import Any, TypeVar
+from uuid import UUID
+
+import click
+from rich.console import Console
+
+from workouter_cli.application.formatters.factory import get_formatter
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+)
+from workouter_cli.domain.entities.session import Session
+from workouter_cli.presentation.context import CLIContext
+
+
+T = TypeVar("T")
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def _render(ctx: CLIContext, payload: object, command: str) -> None:
+    formatter = get_formatter(ctx.output_json)
+    rendered = formatter.format(payload, command=command)
+    if isinstance(rendered, str):
+        click.echo(rendered)
+    else:
+        Console().print(rendered)
+
+
+@click.group(name="insights")
+def insights() -> None:
+    """Training insights commands."""
+
+
+@insights.command(name="volume")
+@click.option("--mesocycle-id", type=click.UUID, required=True)
+@click.option("--muscle-group-id", type=click.UUID, default=None)
+@click.pass_obj
+def volume_insight(
+    ctx: CLIContext,
+    mesocycle_id: UUID,
+    muscle_group_id: UUID | None,
+) -> None:
+    """Show mesocycle volume insight."""
+
+    insight: VolumeInsight = _run(
+        ctx.insight_service.volume(
+            mesocycle_id=str(mesocycle_id),
+            muscle_group_id=str(muscle_group_id) if muscle_group_id is not None else None,
+        )
+    )
+    _render(ctx, asdict(insight), command="insights volume")
+
+
+@insights.command(name="intensity")
+@click.option("--mesocycle-id", type=click.UUID, required=True)
+@click.pass_obj
+def intensity_insight(ctx: CLIContext, mesocycle_id: UUID) -> None:
+    """Show mesocycle intensity insight."""
+
+    insight: IntensityInsight = _run(ctx.insight_service.intensity(mesocycle_id=str(mesocycle_id)))
+    _render(ctx, asdict(insight), command="insights intensity")
+
+
+@insights.command(name="overload")
+@click.option("--mesocycle-id", type=click.UUID, required=True)
+@click.option("--exercise-id", type=click.UUID, required=True)
+@click.pass_obj
+def overload_insight(ctx: CLIContext, mesocycle_id: UUID, exercise_id: UUID) -> None:
+    """Show progressive overload insight."""
+
+    insight: ProgressiveOverloadInsight = _run(
+        ctx.insight_service.overload(
+            mesocycle_id=str(mesocycle_id),
+            exercise_id=str(exercise_id),
+        )
+    )
+    _render(ctx, asdict(insight), command="insights overload")
+
+
+@insights.command(name="history")
+@click.option("--exercise-id", type=click.UUID, required=True)
+@click.option("--routine-id", type=click.UUID, default=None)
+@click.option("--page", type=int, default=1, show_default=True)
+@click.option("--page-size", type=int, default=20, show_default=True)
+@click.pass_obj
+def history_insight(
+    ctx: CLIContext,
+    exercise_id: UUID,
+    routine_id: UUID | None,
+    page: int,
+    page_size: int,
+) -> None:
+    """Show exercise history insight."""
+
+    items: list[Session]
+    pagination: dict[str, int]
+    items, pagination = _run(
+        ctx.insight_service.history(
+            exercise_id=str(exercise_id),
+            routine_id=str(routine_id) if routine_id is not None else None,
+            page=page,
+            page_size=page_size,
+        )
+    )
+    payload = {
+        "items": [asdict(item) for item in items],
+        "total": pagination["total"],
+        "page": pagination["page"],
+        "page_size": pagination["pageSize"],
+        "total_pages": pagination["totalPages"],
+    }
+    _render(ctx, payload, command="insights history")

--- a/cli/src/workouter_cli/presentation/context.py
+++ b/cli/src/workouter_cli/presentation/context.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from workouter_cli.application.services.backup_service import BackupService
+from workouter_cli.application.services.bodyweight_service import BodyweightService
 from workouter_cli.application.services.calendar_service import CalendarService
 from workouter_cli.application.services.exercise_service import ExerciseService
+from workouter_cli.application.services.insight_service import InsightService
 from workouter_cli.application.services.mesocycle_service import MesocycleService
 from workouter_cli.application.services.routine_service import RoutineService
 from workouter_cli.application.services.session_service import SessionService
@@ -22,6 +25,9 @@ class CLIContext:
     client: GraphQLClient
     output_json: bool
     timeout: int
+    backup_service: BackupService
+    bodyweight_service: BodyweightService
+    insight_service: InsightService
     exercise_service: ExerciseService
     mesocycle_service: MesocycleService
     routine_service: RoutineService

--- a/cli/tests/integration/test_backup_commands.py
+++ b/cli/tests/integration/test_backup_commands.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def test_backup_trigger_command(mocker) -> None:  # type: ignore[no-untyped-def]
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "mutation TriggerBackup" in query:
+            return {
+                "triggerBackup": {
+                    "success": True,
+                    "filename": "backup-20260101.sql",
+                    "sizeBytes": 1024,
+                    "createdAt": "2026-01-01T10:00:00Z",
+                }
+            }
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+    result = runner.invoke(cli, ["--json", "backup", "trigger"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+    assert payload["success"] is True
+    assert payload["data"]["success"] is True
+    assert payload["data"]["filename"] == "backup-20260101.sql"

--- a/cli/tests/integration/test_bodyweight_commands.py
+++ b/cli/tests/integration/test_bodyweight_commands.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _bodyweight_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "weightKg": 80.5,
+        "recordedAt": "2026-01-01T08:00:00Z",
+        "notes": "Morning fasted",
+        "createdAt": "2026-01-01T08:00:00Z",
+    }
+
+
+def test_bodyweight_list_log_update_delete_commands(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query ListBodyweightLogs" in query:
+            calls.append("list")
+            return {
+                "bodyweightLogs": {
+                    "items": [_bodyweight_payload()],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 20,
+                    "totalPages": 1,
+                }
+            }
+        if "mutation LogBodyweight" in query:
+            calls.append("log")
+            return {"logBodyweight": _bodyweight_payload()}
+        if "mutation UpdateBodyweightLog" in query:
+            calls.append("update")
+            payload = _bodyweight_payload()
+            payload["notes"] = "Updated"
+            return {"updateBodyweightLog": payload}
+        if "mutation DeleteBodyweightLog" in query:
+            calls.append("delete")
+            return {"deleteBodyweightLog": True}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    list_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "bodyweight",
+            "list",
+            "--date-from",
+            "2026-01-01T00:00:00",
+            "--date-to",
+            "2026-01-02T00:00:00",
+        ],
+    )
+    assert list_result.exit_code == 0
+    assert json.loads(list_result.output.strip())["data"]["items"][0]["weight_kg"] == 80.5
+
+    log_result = runner.invoke(
+        cli,
+        ["--json", "bodyweight", "log", "--weight", "80.5", "--notes", "Morning fasted"],
+    )
+    assert log_result.exit_code == 0
+
+    update_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "bodyweight",
+            "update",
+            "11111111-1111-1111-1111-111111111111",
+            "--notes",
+            "Updated",
+        ],
+    )
+    assert update_result.exit_code == 0
+
+    delete_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "bodyweight",
+            "delete",
+            "11111111-1111-1111-1111-111111111111",
+            "--force",
+        ],
+    )
+    assert delete_result.exit_code == 0
+    assert json.loads(delete_result.output.strip())["data"]["deleted"] is True
+    assert calls == ["list", "log", "update", "delete"]
+
+
+def test_bodyweight_dry_run_and_validation(mocker) -> None:  # type: ignore[no-untyped-def]
+    mock_execute = AsyncMock()
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        mock_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    dry_run_result = runner.invoke(
+        cli,
+        ["--json", "bodyweight", "log", "--weight", "80.0", "--dry-run"],
+    )
+    assert dry_run_result.exit_code == 0
+    assert json.loads(dry_run_result.output.strip())["data"]["dry_run"] is True
+
+    validation_result = runner.invoke(
+        cli,
+        ["--json", "bodyweight", "update", "11111111-1111-1111-1111-111111111111"],
+    )
+    assert validation_result.exit_code == 1
+    assert json.loads(validation_result.output.strip())["error"]["code"] == "VALIDATION_ERROR"
+    mock_execute.assert_not_called()

--- a/cli/tests/integration/test_calendar_commands.py
+++ b/cli/tests/integration/test_calendar_commands.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _calendar_day_payload() -> dict[str, object]:
+    return {
+        "date": "2026-01-01",
+        "plannedSession": {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "routine": {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "name": "Push A",
+            },
+            "dayOfWeek": 4,
+            "date": "2026-01-01",
+            "notes": None,
+        },
+        "session": None,
+        "isCompleted": False,
+        "isRestDay": False,
+    }
+
+
+def test_calendar_day_and_range_commands(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query CalendarDay" in query:
+            calls.append("day")
+            return {"calendarDay": _calendar_day_payload()}
+        if "query CalendarRange" in query:
+            calls.append("range")
+            return {"calendarRange": [_calendar_day_payload()]}
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    day_result = runner.invoke(
+        cli,
+        ["--json", "calendar", "day", "--date", "2026-01-01"],
+    )
+    assert day_result.exit_code == 0
+    assert json.loads(day_result.output.strip())["data"]["date"] == "2026-01-01"
+
+    range_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "calendar",
+            "range",
+            "--start-date",
+            "2026-01-01",
+            "--end-date",
+            "2026-01-07",
+        ],
+    )
+    assert range_result.exit_code == 0
+    assert json.loads(range_result.output.strip())["data"][0]["date"] == "2026-01-01"
+
+    assert calls == ["day", "range"]

--- a/cli/tests/integration/test_insight_commands.py
+++ b/cli/tests/integration/test_insight_commands.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from workouter_cli.main import cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "WORKOUTER_API_URL": "http://localhost:8000/graphql",
+        "WORKOUTER_API_KEY": "test-api-key",
+        "WORKOUTER_CLI_TIMEOUT": "30",
+        "WORKOUTER_CLI_LOG_LEVEL": "INFO",
+    }
+
+
+def _session_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "plannedSessionId": None,
+        "mesocycleId": "22222222-2222-2222-2222-222222222222",
+        "routineId": "33333333-3333-3333-3333-333333333333",
+        "status": "COMPLETED",
+        "startedAt": "2026-01-01T10:00:00Z",
+        "completedAt": "2026-01-01T11:00:00Z",
+        "notes": None,
+        "exercises": [],
+    }
+
+
+def test_insight_commands_json(mocker) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    async def fake_execute(self, query: str, variables=None):  # type: ignore[no-untyped-def]
+        if "query MesocycleVolumeInsight" in query:
+            calls.append("volume")
+            return {
+                "mesocycleVolumeInsight": {
+                    "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                    "weeklyVolumes": [
+                        {
+                            "weekNumber": 1,
+                            "muscleGroupId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                            "muscleGroupName": "Chest",
+                            "setCount": 12,
+                        }
+                    ],
+                    "totalSets": 12,
+                    "muscleGroupBreakdown": [
+                        {
+                            "muscleGroupId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                            "muscleGroupName": "Chest",
+                            "totalSets": 12,
+                        }
+                    ],
+                }
+            }
+        if "query MesocycleIntensityInsight" in query:
+            calls.append("intensity")
+            return {
+                "mesocycleIntensityInsight": {
+                    "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                    "weeklyIntensities": [{"weekNumber": 1, "avgRir": 2.0}],
+                    "overallAvgRir": 2.0,
+                }
+            }
+        if "query ProgressiveOverloadInsight" in query:
+            calls.append("overload")
+            return {
+                "progressiveOverloadInsight": {
+                    "exerciseId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                    "weeklyProgress": [
+                        {
+                            "weekNumber": 1,
+                            "maxWeight": 80.0,
+                            "avgReps": 10.0,
+                            "avgRir": 2.0,
+                        }
+                    ],
+                    "estimatedOneRepMaxProgression": [100.0],
+                }
+            }
+        if "query ExerciseHistory" in query:
+            calls.append("history")
+            return {
+                "exerciseHistory": {
+                    "items": [_session_payload()],
+                    "total": 1,
+                    "page": 1,
+                    "pageSize": 20,
+                    "totalPages": 1,
+                }
+            }
+        raise AssertionError("Unexpected GraphQL operation")
+
+    mocker.patch(
+        "workouter_cli.infrastructure.graphql.client.GraphQLClient.execute",
+        new=fake_execute,
+    )
+
+    runner = CliRunner(env=_base_env())
+
+    volume_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "insights",
+            "volume",
+            "--mesocycle-id",
+            "22222222-2222-2222-2222-222222222222",
+        ],
+    )
+    assert volume_result.exit_code == 0
+    assert json.loads(volume_result.output.strip())["data"]["total_sets"] == 12
+
+    intensity_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "insights",
+            "intensity",
+            "--mesocycle-id",
+            "22222222-2222-2222-2222-222222222222",
+        ],
+    )
+    assert intensity_result.exit_code == 0
+
+    overload_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "insights",
+            "overload",
+            "--mesocycle-id",
+            "22222222-2222-2222-2222-222222222222",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        ],
+    )
+    assert overload_result.exit_code == 0
+
+    history_result = runner.invoke(
+        cli,
+        [
+            "--json",
+            "insights",
+            "history",
+            "--exercise-id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        ],
+    )
+    assert history_result.exit_code == 0
+    assert json.loads(history_result.output.strip())["data"]["items"][0]["status"] == "COMPLETED"
+
+    assert calls == ["volume", "intensity", "overload", "history"]

--- a/cli/tests/integration/test_schema_command.py
+++ b/cli/tests/integration/test_schema_command.py
@@ -95,3 +95,58 @@ def test_schema_command_outputs_valid_json_for_mesocycles_add_session() -> None:
     options = {item["name"] for item in payload["options"]}
     assert "--day-of-week" in options
     assert "--routine-id" in options
+
+
+def test_schema_command_outputs_valid_json_for_bodyweight_log() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "bodyweight log"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "bodyweight log"
+    assert payload["description"] == "Log bodyweight."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--weight" in options
+    assert "--recorded-at" in options
+
+
+def test_schema_command_outputs_valid_json_for_insights_volume() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "insights volume"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "insights volume"
+    assert payload["description"] == "Show mesocycle volume insight."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--mesocycle-id" in options
+
+
+def test_schema_command_outputs_valid_json_for_calendar_range() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "calendar range"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "calendar range"
+    assert payload["description"] == "Show calendar range."
+
+    options = {item["name"] for item in payload["options"]}
+    assert "--start-date" in options
+    assert "--end-date" in options
+
+
+def test_schema_command_outputs_valid_json_for_backup_trigger() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["schema", "backup trigger"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip())
+
+    assert payload["command"] == "backup trigger"
+    assert payload["description"] == "Trigger database backup."

--- a/cli/tests/unit/test_backup_repository.py
+++ b/cli/tests/unit/test_backup_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.mutations.backup import TRIGGER_BACKUP
+from workouter_cli.infrastructure.repositories.backup import GraphQLBackupRepository
+
+
+@pytest.mark.asyncio
+async def test_repository_trigger_maps_backup_result() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "triggerBackup": {
+                "success": True,
+                "filename": "backup-20260101.sql",
+                "sizeBytes": 1024,
+                "createdAt": "2026-01-01T10:00:00Z",
+            }
+        }
+    )
+
+    repository = GraphQLBackupRepository(client=client)
+    result = await repository.trigger()
+
+    assert result.success is True
+    assert result.filename == "backup-20260101.sql"
+    client.execute.assert_awaited_once_with(TRIGGER_BACKUP, {})

--- a/cli/tests/unit/test_backup_service.py
+++ b/cli/tests/unit/test_backup_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.backup_service import BackupService
+from workouter_cli.domain.entities.backup import BackupResult
+
+
+def _backup_result() -> BackupResult:
+    return BackupResult(
+        success=True,
+        filename="backup-20260101.sql",
+        size_bytes=1024,
+        created_at="2026-01-01T10:00:00Z",
+    )
+
+
+@pytest.mark.asyncio
+async def test_backup_service_trigger_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.trigger = AsyncMock(return_value=_backup_result())
+    service = BackupService(backup_repository=repository)
+
+    result = await service.trigger()
+
+    assert result.success is True
+    repository.trigger.assert_awaited_once_with()

--- a/cli/tests/unit/test_bodyweight_repository.py
+++ b/cli/tests/unit/test_bodyweight_repository.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.mutations.bodyweight import (
+    DELETE_BODYWEIGHT_LOG,
+    LOG_BODYWEIGHT,
+    UPDATE_BODYWEIGHT_LOG,
+)
+from workouter_cli.infrastructure.graphql.queries.bodyweight import LIST_BODYWEIGHT_LOGS
+from workouter_cli.infrastructure.repositories.bodyweight import GraphQLBodyweightRepository
+
+
+def _bodyweight_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "weightKg": 80.5,
+        "recordedAt": "2026-01-01T08:00:00Z",
+        "notes": "Morning",
+        "createdAt": "2026-01-01T08:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_list_maps_logs_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "bodyweightLogs": {
+                "items": [_bodyweight_payload()],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLBodyweightRepository(client=client)
+    items, pagination = await repository.list(page=1, page_size=20)
+
+    assert len(items) == 1
+    assert items[0].weight_kg == 80.5
+    assert pagination == {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1}
+    client.execute.assert_awaited_once_with(
+        LIST_BODYWEIGHT_LOGS,
+        {"pagination": {"page": 1, "pageSize": 20}, "dateFrom": None, "dateTo": None},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_log_maps_entry() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"logBodyweight": _bodyweight_payload()})
+
+    repository = GraphQLBodyweightRepository(client=client)
+    item = await repository.log({"weightKg": 80.5, "notes": "Morning"})
+
+    assert item.notes == "Morning"
+    client.execute.assert_awaited_once_with(
+        LOG_BODYWEIGHT,
+        {"input": {"weightKg": 80.5, "notes": "Morning"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_update_maps_entry() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"updateBodyweightLog": _bodyweight_payload()})
+
+    repository = GraphQLBodyweightRepository(client=client)
+    item = await repository.update("11111111-1111-1111-1111-111111111111", {"notes": "Updated"})
+
+    assert item.id == "11111111-1111-1111-1111-111111111111"
+    client.execute.assert_awaited_once_with(
+        UPDATE_BODYWEIGHT_LOG,
+        {"id": "11111111-1111-1111-1111-111111111111", "input": {"notes": "Updated"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_delete_maps_boolean() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"deleteBodyweightLog": True})
+
+    repository = GraphQLBodyweightRepository(client=client)
+    deleted = await repository.delete("11111111-1111-1111-1111-111111111111")
+
+    assert deleted is True
+    client.execute.assert_awaited_once_with(
+        DELETE_BODYWEIGHT_LOG,
+        {"id": "11111111-1111-1111-1111-111111111111"},
+    )

--- a/cli/tests/unit/test_bodyweight_service.py
+++ b/cli/tests/unit/test_bodyweight_service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.bodyweight_service import BodyweightService
+from workouter_cli.domain.entities.bodyweight import BodyweightLog
+
+
+def _bodyweight_log() -> BodyweightLog:
+    return BodyweightLog(
+        id="11111111-1111-1111-1111-111111111111",
+        weight_kg=80.5,
+        recorded_at="2026-01-01T08:00:00Z",
+        notes="Morning",
+        created_at="2026-01-01T08:00:00Z",
+    )
+
+
+@pytest.mark.asyncio
+async def test_bodyweight_service_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.list = AsyncMock(
+        return_value=([_bodyweight_log()], {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1})
+    )
+    repository.log = AsyncMock(return_value=_bodyweight_log())
+    repository.update = AsyncMock(return_value=_bodyweight_log())
+    repository.delete = AsyncMock(return_value=True)
+
+    service = BodyweightService(bodyweight_repository=repository)
+
+    items, pagination = await service.list(page=1, page_size=20)
+    logged = await service.log({"weightKg": 80.5})
+    updated = await service.update("11111111-1111-1111-1111-111111111111", {"notes": "Updated"})
+    deleted = await service.delete("11111111-1111-1111-1111-111111111111")
+
+    assert len(items) == 1
+    assert pagination["total"] == 1
+    assert logged.weight_kg == 80.5
+    assert updated.id == "11111111-1111-1111-1111-111111111111"
+    assert deleted is True
+
+    repository.list.assert_awaited_once_with(page=1, page_size=20, date_from=None, date_to=None)
+    repository.log.assert_awaited_once_with({"weightKg": 80.5})
+    repository.update.assert_awaited_once_with(
+        "11111111-1111-1111-1111-111111111111", {"notes": "Updated"}
+    )
+    repository.delete.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")

--- a/cli/tests/unit/test_calendar_repository.py
+++ b/cli/tests/unit/test_calendar_repository.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.queries.calendar import CALENDAR_DAY, CALENDAR_RANGE
+from workouter_cli.infrastructure.repositories.calendar import GraphQLCalendarRepository
+
+
+def _calendar_day_payload() -> dict[str, object]:
+    return {
+        "date": "2026-01-01",
+        "plannedSession": {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "routine": {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "name": "Push A",
+            },
+            "dayOfWeek": 4,
+            "date": "2026-01-01",
+            "notes": None,
+        },
+        "session": None,
+        "isCompleted": False,
+        "isRestDay": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_day_maps_calendar_day() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"calendarDay": _calendar_day_payload()})
+
+    repository = GraphQLCalendarRepository(client=client)
+    day = await repository.day("2026-01-01")
+
+    assert day.date == "2026-01-01"
+    assert day.is_rest_day is False
+    client.execute.assert_awaited_once_with(CALENDAR_DAY, {"date": "2026-01-01"})
+
+
+@pytest.mark.asyncio
+async def test_repository_range_maps_calendar_days() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(return_value={"calendarRange": [_calendar_day_payload()]})
+
+    repository = GraphQLCalendarRepository(client=client)
+    days = await repository.range("2026-01-01", "2026-01-07")
+
+    assert len(days) == 1
+    assert days[0].planned_session is not None
+    client.execute.assert_awaited_once_with(
+        CALENDAR_RANGE,
+        {"startDate": "2026-01-01", "endDate": "2026-01-07"},
+    )

--- a/cli/tests/unit/test_calendar_service.py
+++ b/cli/tests/unit/test_calendar_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.calendar_service import CalendarService
+from workouter_cli.domain.entities.calendar import CalendarDay
+
+
+def _calendar_day() -> CalendarDay:
+    return CalendarDay(
+        date="2026-01-01",
+        planned_session=None,
+        session_id=None,
+        is_completed=False,
+        is_rest_day=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_calendar_service_day_and_range_delegate(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.day = AsyncMock(return_value=_calendar_day())
+    repository.range = AsyncMock(return_value=[_calendar_day()])
+    service = CalendarService(calendar_repository=repository)
+
+    day = await service.day("2026-01-01")
+    days = await service.range("2026-01-01", "2026-01-07")
+
+    assert day.date == "2026-01-01"
+    assert len(days) == 1
+    repository.day.assert_awaited_once_with("2026-01-01")
+    repository.range.assert_awaited_once_with("2026-01-01", "2026-01-07")

--- a/cli/tests/unit/test_insight_repository.py
+++ b/cli/tests/unit/test_insight_repository.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.infrastructure.graphql.queries.insight import (
+    EXERCISE_HISTORY,
+    MESOCYCLE_INTENSITY_INSIGHT,
+    MESOCYCLE_VOLUME_INSIGHT,
+    PROGRESSIVE_OVERLOAD_INSIGHT,
+)
+from workouter_cli.infrastructure.repositories.insight import GraphQLInsightRepository
+
+
+def _session_payload() -> dict[str, object]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "plannedSessionId": None,
+        "mesocycleId": "22222222-2222-2222-2222-222222222222",
+        "routineId": "33333333-3333-3333-3333-333333333333",
+        "status": "COMPLETED",
+        "startedAt": "2026-01-01T10:00:00Z",
+        "completedAt": "2026-01-01T11:00:00Z",
+        "notes": None,
+        "exercises": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_volume_maps_payload() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "mesocycleVolumeInsight": {
+                "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                "weeklyVolumes": [
+                    {
+                        "weekNumber": 1,
+                        "muscleGroupId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        "muscleGroupName": "Chest",
+                        "setCount": 12,
+                    }
+                ],
+                "totalSets": 12,
+                "muscleGroupBreakdown": [
+                    {
+                        "muscleGroupId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        "muscleGroupName": "Chest",
+                        "totalSets": 12,
+                    }
+                ],
+            }
+        }
+    )
+
+    repository = GraphQLInsightRepository(client=client)
+    insight = await repository.volume("22222222-2222-2222-2222-222222222222")
+
+    assert insight.total_sets == 12
+    client.execute.assert_awaited_once_with(
+        MESOCYCLE_VOLUME_INSIGHT,
+        {"mesocycleId": "22222222-2222-2222-2222-222222222222", "muscleGroupId": None},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_intensity_maps_payload() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "mesocycleIntensityInsight": {
+                "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                "weeklyIntensities": [{"weekNumber": 1, "avgRir": 2.0}],
+                "overallAvgRir": 2.0,
+            }
+        }
+    )
+
+    repository = GraphQLInsightRepository(client=client)
+    insight = await repository.intensity("22222222-2222-2222-2222-222222222222")
+
+    assert insight.overall_avg_rir == 2.0
+    client.execute.assert_awaited_once_with(
+        MESOCYCLE_INTENSITY_INSIGHT,
+        {"mesocycleId": "22222222-2222-2222-2222-222222222222"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_overload_maps_payload() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "progressiveOverloadInsight": {
+                "exerciseId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "mesocycleId": "22222222-2222-2222-2222-222222222222",
+                "weeklyProgress": [
+                    {
+                        "weekNumber": 1,
+                        "maxWeight": 80.0,
+                        "avgReps": 10.0,
+                        "avgRir": 2.0,
+                    }
+                ],
+                "estimatedOneRepMaxProgression": [100.0],
+            }
+        }
+    )
+
+    repository = GraphQLInsightRepository(client=client)
+    insight = await repository.overload(
+        "22222222-2222-2222-2222-222222222222",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    )
+
+    assert insight.estimated_one_rep_max_progression[0] == 100.0
+    client.execute.assert_awaited_once_with(
+        PROGRESSIVE_OVERLOAD_INSIGHT,
+        {
+            "mesocycleId": "22222222-2222-2222-2222-222222222222",
+            "exerciseId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_history_maps_payload_and_pagination() -> None:
+    client = AsyncMock()
+    client.execute = AsyncMock(
+        return_value={
+            "exerciseHistory": {
+                "items": [_session_payload()],
+                "total": 1,
+                "page": 1,
+                "pageSize": 20,
+                "totalPages": 1,
+            }
+        }
+    )
+
+    repository = GraphQLInsightRepository(client=client)
+    items, pagination = await repository.history(
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        page=1,
+        page_size=20,
+    )
+
+    assert len(items) == 1
+    assert items[0].status == "COMPLETED"
+    assert pagination == {"total": 1, "page": 1, "pageSize": 20, "totalPages": 1}
+    client.execute.assert_awaited_once_with(
+        EXERCISE_HISTORY,
+        {
+            "exerciseId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "routineId": None,
+            "pagination": {"page": 1, "pageSize": 20},
+        },
+    )

--- a/cli/tests/unit/test_insight_service.py
+++ b/cli/tests/unit/test_insight_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workouter_cli.application.services.insight_service import InsightService
+from workouter_cli.domain.entities.insight import (
+    IntensityInsight,
+    ProgressiveOverloadInsight,
+    VolumeInsight,
+)
+from workouter_cli.domain.entities.session import Session
+
+
+def _volume_insight() -> VolumeInsight:
+    return VolumeInsight(
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        weekly_volumes=(),
+        total_sets=12,
+        muscle_group_breakdown=(),
+    )
+
+
+def _intensity_insight() -> IntensityInsight:
+    return IntensityInsight(
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        weekly_intensities=(),
+        overall_avg_rir=2.0,
+    )
+
+
+def _overload_insight() -> ProgressiveOverloadInsight:
+    return ProgressiveOverloadInsight(
+        exercise_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        weekly_progress=(),
+        estimated_one_rep_max_progression=(100.0,),
+    )
+
+
+def _session() -> Session:
+    return Session(
+        id="11111111-1111-1111-1111-111111111111",
+        planned_session_id=None,
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        routine_id="33333333-3333-3333-3333-333333333333",
+        status="COMPLETED",
+        started_at="2026-01-01T10:00:00Z",
+        completed_at="2026-01-01T11:00:00Z",
+        notes=None,
+        exercises=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_insight_service_delegates(mocker) -> None:  # type: ignore[no-untyped-def]
+    repository = mocker.Mock()
+    repository.volume = AsyncMock(return_value=_volume_insight())
+    repository.intensity = AsyncMock(return_value=_intensity_insight())
+    repository.overload = AsyncMock(return_value=_overload_insight())
+    repository.history = AsyncMock(return_value=([_session()], {"total": 1}))
+
+    service = InsightService(insight_repository=repository)
+
+    volume = await service.volume("22222222-2222-2222-2222-222222222222")
+    intensity = await service.intensity("22222222-2222-2222-2222-222222222222")
+    overload = await service.overload(
+        "22222222-2222-2222-2222-222222222222",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    )
+    items, pagination = await service.history("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+    assert volume.total_sets == 12
+    assert intensity.overall_avg_rir == 2.0
+    assert overload.estimated_one_rep_max_progression[0] == 100.0
+    assert len(items) == 1
+    assert pagination["total"] == 1
+
+    repository.volume.assert_awaited_once_with(
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        muscle_group_id=None,
+    )
+    repository.intensity.assert_awaited_once_with(
+        mesocycle_id="22222222-2222-2222-2222-222222222222"
+    )
+    repository.overload.assert_awaited_once_with(
+        mesocycle_id="22222222-2222-2222-2222-222222222222",
+        exercise_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    )
+    repository.history.assert_awaited_once_with(
+        exercise_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        routine_id=None,
+        page=1,
+        page_size=20,
+    )

--- a/cli/tests/unit/test_main.py
+++ b/cli/tests/unit/test_main.py
@@ -112,6 +112,38 @@ def test_help_includes_mesocycles_command_group() -> None:
     assert "mesocycles" in result.output
 
 
+def test_help_includes_bodyweight_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "bodyweight" in result.output
+
+
+def test_help_includes_insights_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "insights" in result.output
+
+
+def test_help_includes_calendar_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "calendar" in result.output
+
+
+def test_help_includes_backup_command_group() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "backup" in result.output
+
+
 def test_schema_sessions_list_outputs_machine_readable_definition() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["schema", "sessions list"])


### PR DESCRIPTION
## Summary
- implement full vertical slices for `bodyweight`, `insights`, `calendar`, and `backup` command groups (domain entities/protocols, services, GraphQL queries/mutations, repositories, CLI commands, and root registration)
- add `calendar range` and `backup trigger`, and wire all new commands through existing JSON formatting and semantic error handling paths
- add integration and unit coverage for new commands/services/repositories, plus schema/help assertions for the new root groups and subcommands

## Validation
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest`