### PR TITLE
[E2E] Add per-test isolation and cleanup safety

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -4,6 +4,7 @@ import json
 import os
 import socket
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -24,6 +25,10 @@ class APIRuntime:
     base_url: str
     graphql_url: str
     api_key: str
+    runtime_dir: Path
+    database_path: Path
+    backups_dir: Path
+    log_path: Path
 
 
 @dataclass(frozen=True)
@@ -118,60 +123,69 @@ def _wait_for_health(
     )
 
 
-@pytest.fixture(scope="session")
-def api_runtime(tmp_path_factory: pytest.TempPathFactory) -> Iterator[APIRuntime]:
-    temp_dir = tmp_path_factory.mktemp("e2e-runtime")
-    data_dir = temp_dir / "data"
-    backups_dir = temp_dir / "backups"
-    data_dir.mkdir(parents=True, exist_ok=True)
-    backups_dir.mkdir(parents=True, exist_ok=True)
+@pytest.fixture
+def api_runtime() -> Iterator[APIRuntime]:
+    with tempfile.TemporaryDirectory(prefix="workouter-e2e-") as runtime_dir_str:
+        runtime_dir = Path(runtime_dir_str)
+        data_dir = runtime_dir / "data"
+        backups_dir = runtime_dir / "backups"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        backups_dir.mkdir(parents=True, exist_ok=True)
 
-    port = _get_free_port()
-    api_key = f"e2e-key-{port}"
-    config_path = temp_dir / "config.e2e.yaml"
-    log_path = temp_dir / "api.log"
-    _write_api_config(config_path, port, api_key, data_dir, backups_dir)
+        port = _get_free_port()
+        api_key = f"e2e-key-{port}"
+        config_path = runtime_dir / "config.e2e.yaml"
+        log_path = runtime_dir / "api.log"
+        database_path = data_dir / "e2e.sqlite"
+        _write_api_config(config_path, port, api_key, data_dir, backups_dir)
 
-    env = os.environ.copy()
-    env["CONFIG_PATH"] = str(config_path)
-    env["PYTHONPATH"] = "src"
+        env = os.environ.copy()
+        env["CONFIG_PATH"] = str(config_path)
+        env["PYTHONPATH"] = "src"
 
-    with log_path.open("w", encoding="utf-8") as log_file:
-        process: subprocess.Popen[str] = subprocess.Popen(
-            [
-                "uv",
-                "run",
-                "uvicorn",
-                "app.main:create_app",
-                "--factory",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-            ],
-            cwd=API_DIR,
-            env=env,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process: subprocess.Popen[str] = subprocess.Popen(
+                [
+                    "uv",
+                    "run",
+                    "uvicorn",
+                    "app.main:create_app",
+                    "--factory",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                ],
+                cwd=API_DIR,
+                env=env,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
 
-    base_url = f"http://127.0.0.1:{port}"
-    _wait_for_health(url=f"{base_url}/health", process=process, log_path=log_path)
+        base_url = f"http://127.0.0.1:{port}"
 
-    try:
-        yield APIRuntime(
-            base_url=base_url,
-            graphql_url=f"{base_url}/graphql",
-            api_key=api_key,
-        )
-    finally:
-        process.terminate()
         try:
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=5)
+            _wait_for_health(
+                url=f"{base_url}/health", process=process, log_path=log_path
+            )
+            yield APIRuntime(
+                base_url=base_url,
+                graphql_url=f"{base_url}/graphql",
+                api_key=api_key,
+                runtime_dir=runtime_dir,
+                database_path=database_path,
+                backups_dir=backups_dir,
+                log_path=log_path,
+            )
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
 
 
 @pytest.fixture

--- a/e2e/test_smoke.py
+++ b/e2e/test_smoke.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from pathlib import Path
+import time
 from urllib.request import Request, urlopen
 
 from conftest import APIRuntime, CLIResult
 
 
-def test_api_and_cli_smoke(
-    api_runtime: APIRuntime, run_cli: Callable[[list[str]], CLIResult]
-) -> None:
+_RUNTIME_DIRS: list[Path] = []
+
+
+def _assert_api_health(api_runtime: APIRuntime) -> None:
     request = Request(url=f"{api_runtime.base_url}/health", method="GET")
     with urlopen(request, timeout=3) as response:  # noqa: S310
         assert int(getattr(response, "status", 0)) == 200
@@ -17,12 +20,68 @@ def test_api_and_cli_smoke(
         assert health_payload["status"] == "ok"
         assert health_payload["database"] == "ok"
 
+
+def _list_items(run_cli: Callable[[list[str]], CLIResult]) -> list[dict[str, object]]:
     result = run_cli(["--json", "exercises", "list"])
     assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
-
     payload = json.loads(result.stdout.strip())
     assert payload["success"] is True
-    assert isinstance(payload["data"], dict)
-    assert "items" in payload["data"]
-    assert "metadata" in payload
-    assert payload["metadata"]["command"] == "exercises list"
+    data = payload["data"]
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    return items
+
+
+def _wait_for_backup_artifact(
+    backups_dir: Path, timeout_seconds: float = 5.0
+) -> list[Path]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        artifacts = [path for path in backups_dir.iterdir() if path.is_file()]
+        if artifacts:
+            return artifacts
+        time.sleep(0.1)
+    return []
+
+
+def test_01_e2e_isolation_seed_and_backup(
+    api_runtime: APIRuntime, run_cli: Callable[[list[str]], CLIResult]
+) -> None:
+    _assert_api_health(api_runtime)
+    assert _list_items(run_cli) == []
+
+    create_result = run_cli(
+        ["--json", "exercises", "create", "--name", "E2E Isolation Exercise"]
+    )
+    assert create_result.returncode == 0, (
+        f"Create failed with stderr: {create_result.stderr}"
+    )
+    created_payload = json.loads(create_result.stdout.strip())
+    assert created_payload["success"] is True
+
+    assert len(_list_items(run_cli)) == 1
+
+    backup_result = run_cli(["--json", "backup", "trigger"])
+    assert backup_result.returncode == 0, (
+        f"Backup failed with stderr: {backup_result.stderr}"
+    )
+    backup_payload = json.loads(backup_result.stdout.strip())
+    assert backup_payload["success"] is True
+    assert _wait_for_backup_artifact(api_runtime.backups_dir)
+
+    _RUNTIME_DIRS.append(api_runtime.runtime_dir)
+
+
+def test_02_e2e_starts_clean_and_cleans_previous_runtime(
+    api_runtime: APIRuntime, run_cli: Callable[[list[str]], CLIResult]
+) -> None:
+    _assert_api_health(api_runtime)
+
+    assert _RUNTIME_DIRS, "Expected prior test to record runtime directory"
+    previous_runtime_dir = _RUNTIME_DIRS[-1]
+    assert api_runtime.runtime_dir != previous_runtime_dir
+    assert not previous_runtime_dir.exists()
+
+    assert _list_items(run_cli) == []
+    assert list(api_runtime.backups_dir.iterdir()) == []


### PR DESCRIPTION
## Summary
- switch the e2e API runtime fixture from session-scoped to per-test temporary runtimes so each test gets an isolated sqlite database and backup directory
- strengthen teardown behavior to terminate spawned API processes on pass/fail paths while allowing temporary runtime resources to be removed automatically
- expand e2e smoke coverage to validate clean start state, backup artifact scoping, and no cross-test contamination between sequential tests

## Testing
- uv run pytest