### PR TITLE
[CI] Restrict API CI workflow to api/ folder changes

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,8 +1,15 @@
 name: API Test CI
 
 on:
+  push:
+    branches: ["main"]
+    paths:
+      - "api/**"
+      - ".github/workflows/api-ci.yml"
   pull_request:
-    branches: [ "main" ]
+    paths:
+      - "api/**"
+      - ".github/workflows/api-ci.yml"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Restricts the API Test CI workflow to only trigger when changes are made to the `api/` folder or the workflow file itself, preventing unnecessary test runs on unrelated changes.

## Changes

- Added `paths` filter to trigger only on `api/**` changes
- Included the workflow file itself (`.github/workflows/api-ci.yml`) in trigger paths
- Added `push` trigger for main branch (consistent with CLI and E2E workflows)
- Aligns with the pattern already established in CLI and E2E workflows

## Before

The API CI workflow ran on **every** pull request to main, regardless of which files were changed. This meant:
- Documentation-only PRs triggered API tests
- CLI-only changes triggered API tests
- E2E-only changes triggered API tests

## After

The API CI workflow only runs when:
- Changes are made to files in the `api/` directory
- The workflow file itself is modified
- Changes are pushed to main branch (for verification)

## Benefits

- **Faster CI**: Reduces unnecessary workflow runs
- **Resource efficiency**: Saves GitHub Actions minutes
- **Consistency**: Matches the pattern used in CLI and E2E workflows
- **Better UX**: Contributors see only relevant checks on their PRs

## Testing

Verified that the workflow syntax matches the existing patterns in:
- `.github/workflows/cli-ci.yml`
- `.github/workflows/e2e-ci.yml`

## Related Issues

Resolves #43