### PR TITLE
docs: Add MIT License to project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Roberto Gomez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ docker run --rm \
 
 ## License
 
-[Your License Here]
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Workout Tracker API"
 readme = "README.md"
 requires-python = ">=3.14"
+license = {text = "MIT"}
 dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.30",

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Command-line interface for Workouter API"
 readme = "README.md"
 requires-python = ">=3.14"
+license = {text = "MIT"}
 dependencies = [
   "click>=8.1.0",
   "gql[httpx]>=3.5.0",

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -3,6 +3,7 @@ name = "workouter-e2e"
 version = "0.1.0"
 description = "End-to-end test harness for Workouter API + CLI"
 requires-python = ">=3.14"
+license = {text = "MIT"}
 dependencies = [
     "pytest>=8.0",
 ]


### PR DESCRIPTION
## Summary

Adds MIT License to the Workouter project to clarify usage terms and enable open collaboration.

## Changes

- Created `LICENSE` file with standard MIT License text (copyright 2026 Roberto Gomez)
- Updated root `README.md` to reference the LICENSE file in the License section
- Added `license = {text = "MIT"}` field to `pyproject.toml` files in:
  - `api/`
  - `cli/`
  - `e2e/`

## Why MIT License?

The MIT License was chosen because it:
- Allows open collaboration while requiring attribution
- Permits commercial use without restrictions
- Is simple, widely recognized, and trusted by the developer community
- Aligns with dependencies like FastAPI which also use MIT

## Testing

No functional changes - documentation only.

Resolves #27