### PR TITLE
[CLI] Transition Linux release artifact to AppImage

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -18,14 +18,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact_name: workouter-cli-linux-x86_64
-            binary_path: cli/dist/workouter-cli
+            artifact_name: workouter-cli-linux-x86_64.AppImage
+            artifact_path: cli/dist/workouter-cli-linux-x86_64.AppImage
+            build_target: appimage
+            smoke_command: ./dist/workouter-cli-linux-x86_64.AppImage --version
           - os: macos-latest
             artifact_name: workouter-cli-macos-arm64
-            binary_path: cli/dist/workouter-cli
+            artifact_path: cli/dist/workouter-cli
+            build_target: binary
+            smoke_command: ./dist/workouter-cli --version
           - os: windows-latest
             artifact_name: workouter-cli-windows-x86_64.exe
-            binary_path: cli/dist/workouter-cli.exe
+            artifact_path: cli/dist/workouter-cli.exe
+            build_target: binary
+            smoke_command: ./dist/workouter-cli.exe --version
 
     defaults:
       run:
@@ -44,16 +50,12 @@ jobs:
         run: make install
 
       - name: Build binary
-        run: make binary
+        run: make ${{ matrix.build_target }}
 
       - name: Smoke test (Version)
         shell: bash
         run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            version_output=$(./dist/workouter-cli.exe --version)
-          else
-            version_output=$(./dist/workouter-cli --version)
-          fi
+          version_output=$(${{ matrix.smoke_command }})
 
           if [ -z "$version_output" ]; then
             echo "Binary produced empty --version output"
@@ -66,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.binary_path }}
+          path: ${{ matrix.artifact_path }}
           if-no-files-found: error
 
   create-release:
@@ -87,7 +89,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p release-assets
-          cp artifacts/workouter-cli-linux-x86_64/workouter-cli release-assets/workouter-cli-linux-x86_64
+          cp artifacts/workouter-cli-linux-x86_64.AppImage/workouter-cli-linux-x86_64.AppImage release-assets/workouter-cli-linux-x86_64.AppImage
           cp artifacts/workouter-cli-macos-arm64/workouter-cli release-assets/workouter-cli-macos-arm64
           cp artifacts/workouter-cli-windows-x86_64.exe/workouter-cli.exe release-assets/workouter-cli-windows-x86_64.exe
 

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -9,3 +9,4 @@ htmlcov/
 build/
 dist/
 *.spec
+*.AppImage

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev test test-unit test-integration test-cov test-quick lint lint-fix format type-check build binary binary-smoke binary-clean clean docker-build docker-run all
+.PHONY: help install dev test test-unit test-integration test-cov test-quick lint lint-fix format type-check build binary binary-onedir binary-smoke appimage binary-clean clean docker-build docker-run all
 
 help: ## Show this help message
 	@echo "Available targets:"
@@ -59,6 +59,11 @@ binary: ## Build one-file executable via PyInstaller
 	uv run pyinstaller --onefile --name workouter-cli src/workouter_cli/main.py
 	@echo "✓ Binary built: dist/workouter-cli"
 
+binary-onedir: ## Build one-dir executable bundle via PyInstaller
+	@echo "Building one-dir bundle..."
+	uv run pyinstaller --onedir --name workouter-cli src/workouter_cli/main.py
+	@echo "✓ Bundle built: dist/workouter-cli/"
+
 binary-smoke: binary ## Run binary smoke test
 	@echo "Running binary smoke test..."
 	@version_output="$$(./dist/workouter-cli --version)"; \
@@ -72,6 +77,21 @@ binary-clean: ## Remove PyInstaller artifacts
 	@echo "Cleaning binary artifacts..."
 	rm -rf build dist *.spec
 	@echo "✓ Binary artifacts removed"
+
+appimage: binary-onedir ## Build Linux AppImage from one-dir bundle
+	@echo "Building AppImage..."
+	rm -rf AppDir
+	mkdir -p AppDir/usr/bin
+	cp -R dist/workouter-cli/. AppDir/usr/bin/
+	printf '%s\n' '#!/bin/sh' 'HERE=$$(dirname "$$(readlink -f "$$0")")' 'exec "$$HERE/usr/bin/workouter-cli" "$$@"' > AppDir/AppRun
+	chmod +x AppDir/AppRun
+	printf '%s\n' '[Desktop Entry]' 'Type=Application' 'Name=Workouter CLI' 'Exec=workouter-cli --help' 'Icon=workouter-cli' 'Categories=Utility;' 'Terminal=true' > AppDir/workouter-cli.desktop
+	printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><rect width="256" height="256" rx="48" fill="#111827"/><text x="50%" y="56%" dominant-baseline="middle" text-anchor="middle" fill="#f9fafb" font-family="monospace" font-size="72" font-weight="700">WO</text></svg>' > AppDir/workouter-cli.svg
+	ln -sf workouter-cli.svg AppDir/.DirIcon
+	if [ ! -x ./appimagetool-x86_64.AppImage ]; then curl -sSL -o appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage; chmod +x appimagetool-x86_64.AppImage; fi
+	ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-x86_64.AppImage AppDir dist/workouter-cli-linux-x86_64.AppImage
+	rm -rf AppDir build dist/workouter-cli *.spec
+	@echo "✓ AppImage built: dist/workouter-cli-linux-x86_64.AppImage"
 
 docker-run: ## Run CLI in Docker (requires env vars)
 	@echo "Running CLI in Docker..."

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,13 @@ make binary
 ./dist/workouter-cli --help
 ```
 
+For Linux distribution, the release pipeline publishes an AppImage artifact (`workouter-cli-linux-x86_64.AppImage`):
+
+```bash
+chmod +x workouter-cli-linux-x86_64.AppImage
+./workouter-cli-linux-x86_64.AppImage --help
+```
+
 ### Basic Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- transition Linux release packaging from raw PyInstaller onefile binary to `workouter-cli-linux-x86_64.AppImage`
- add `make appimage` flow in `cli/Makefile` (PyInstaller `--onedir` + AppDir + appimagetool packaging)
- make release workflow matrix-driven for build target, smoke command, and artifact path
- keep macOS and Windows release behavior unchanged
- add AppImage usage docs and ignore `*.AppImage` in `cli/.gitignore`
- auto-clean intermediate AppImage build files after packaging so local output remains focused on the final artifact

## Why
The previous Linux onefile binary failed on hardened Linux environments (e.g., Arch) due to executable-stack loader issues in bundled shared libs. AppImage provides a more robust Linux distribution format and avoids shipping the problematic direct onefile artifact.

## Validation
- `make lint` (cli)
- `make type-check` (cli)