### PR TITLE
[CI] Run Linux AppImage smoke test without FUSE

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -55,7 +55,11 @@ jobs:
       - name: Smoke test (Version)
         shell: bash
         run: |
-          version_output=$(${{ matrix.smoke_command }})
+          if [ "${{ runner.os }}" = "Linux" ] && [[ "${{ matrix.artifact_name }}" == *.AppImage ]]; then
+            version_output=$(APPIMAGE_EXTRACT_AND_RUN=1 ${{ matrix.smoke_command }})
+          else
+            version_output=$(${{ matrix.smoke_command }})
+          fi
 
           if [ -z "$version_output" ]; then
             echo "Binary produced empty --version output"

--- a/cli/README.md
+++ b/cli/README.md
@@ -49,6 +49,12 @@ chmod +x workouter-cli-linux-x86_64.AppImage
 ./workouter-cli-linux-x86_64.AppImage --help
 ```
 
+If your system does not provide `libfuse.so.2`, run it in extract-and-run mode:
+
+```bash
+APPIMAGE_EXTRACT_AND_RUN=1 ./workouter-cli-linux-x86_64.AppImage --help
+```
+
 ### Basic Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- update Linux AppImage smoke test in `cli-release` workflow to use `APPIMAGE_EXTRACT_AND_RUN=1`
- keep macOS and Windows smoke tests unchanged
- add README note documenting the same fallback for users on systems missing `libfuse.so.2`

## Why
GitHub Actions Linux runners may not provide usable FUSE runtime (`libfuse.so.2`) for AppImage execution. This caused release workflow smoke tests to fail before the CLI was exercised.

## Validation
- smoke test command now executes AppImage in extract-and-run mode on Linux
- behavior remains unchanged for non-AppImage artifacts