### PR TITLE
[CLI] Bump version to 0.1.2

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "workouter-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "Command-line interface for Workouter API"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/cli/src/workouter_cli/version.py
+++ b/cli/src/workouter_cli/version.py
@@ -1,3 +1,3 @@
 """Version metadata for workouter-cli."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "workouter-cli"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump CLI package version from `0.1.1` to `0.1.2`
- update runtime version constant in `cli/src/workouter_cli/version.py`
- refresh `cli/uv.lock` metadata for the new project version

## Why
Prepare the next release tag (`v0.1.2`) with version metadata aligned across package and runtime reporting.